### PR TITLE
Key machine

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,12 @@ authors = ["Brian Warner <warner@lothar.com>"]
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+sodiumoxide = "0.0.16"
+spake2 = "0.0.4"
+sha2 = "0.7"
+hkdf = "0.4.0"
+hex = "0.3"
+
 
 [dev-dependencies]
 ws = "0.7"

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -96,7 +96,7 @@ pub enum OrderEvent {
 
 #[derive(Debug, PartialEq)]
 pub enum ReceiveEvent {
-    GotCode,
+    GotMessage(String, String, Vec<u8>),
     GotKey(Vec<u8>),
 }
 

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -53,7 +53,7 @@ pub enum InputEvent {
 #[derive(Debug, PartialEq)]
 pub enum KeyEvent {
     GotCode(String),
-    GotPake,
+    GotPake(String),
     GotMessage,
 }
 
@@ -97,7 +97,7 @@ pub enum OrderEvent {
 #[derive(Debug, PartialEq)]
 pub enum ReceiveEvent {
     GotCode,
-    GotKey,
+    GotKey(Vec<u8>),
 }
 
 use server_messages::Message;
@@ -276,9 +276,9 @@ impl Events {
         self.events.push(Event::from(item));
     }
 
-    // pub fn append(&mut self, other: &mut Vec<Event>) {
-    //     self.events.append(&mut other.events);
-    // }
+    pub fn append(&mut self, other: &mut Events) {
+        self.events.append(&mut other.events);
+    }
 }
 
 impl IntoIterator for Events {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -53,7 +53,7 @@ pub enum InputEvent {
 #[derive(Debug, PartialEq)]
 pub enum KeyEvent {
     GotCode(String),
-    GotPake(String),
+    GotPake(Vec<u8>),
     GotMessage,
 }
 
@@ -69,7 +69,7 @@ pub enum ListerEvent {
 pub enum MailboxEvent {
     Connected,
     Lost,
-    RxMessage(String, String, String),
+    RxMessage(String, String, Vec<u8>),
     RxClosed,
     Close(String),
     GotMailbox(String),
@@ -91,7 +91,7 @@ pub enum NameplateEvent {
 
 #[derive(Debug, PartialEq)]
 pub enum OrderEvent {
-    GotMessage(String, String, String),
+    GotMessage(String, String, Vec<u8>),
 }
 
 #[derive(Debug, PartialEq)]

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -74,7 +74,7 @@ pub enum MailboxEvent {
     Close(String),
     GotMailbox(String),
     GotMessage,
-    AddMessage(String, String), // PAKE+VERSION from Key, PHASE from Send
+    AddMessage(String, Vec<u8>), // PAKE+VERSION from Key, PHASE from Send
 }
 
 #[derive(Debug, PartialEq)]
@@ -107,7 +107,7 @@ pub enum RendezvousEvent {
     Start,
     TxBind(String, String), // appid, side
     TxOpen(String),         // mailbox
-    TxAdd(String, String),  // phase, body
+    TxAdd(String, Vec<u8>), // phase, body
     TxClose,
     Stop,
     TxClaim(String),

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -1,8 +1,8 @@
-extern crate serde_json;
 extern crate hex;
+extern crate serde_json;
 
 use sodiumoxide::crypto::secretbox;
-use sha2::{Sha256, Digest};
+use sha2::{Digest, Sha256};
 use spake2;
 use spake2::{Ed25519Group, SPAKE2};
 use hkdf;
@@ -13,15 +13,15 @@ use events::Events;
 // we process these
 use events::KeyEvent;
 // we emit these
-use events::MailboxEvent::{AddMessage as M_AddMessage};
-use events::BossEvent::{GotKey as B_GotKey};
-use events::ReceiveEvent::{GotKey as R_GotKey};
+use events::MailboxEvent::AddMessage as M_AddMessage;
+use events::BossEvent::GotKey as B_GotKey;
+use events::ReceiveEvent::GotKey as R_GotKey;
 
 #[derive(Debug, PartialEq)]
 enum State {
     S00,
-    S10(String), // code
-    S01(String), // pake
+    S10(String),         // code
+    S01(String),         // pake
     S11(String, String), // code, pake
 }
 
@@ -29,7 +29,7 @@ enum SKState {
     S0_Know_Nothing,
     S1_Know_Code,
     S2_Know_Code,
-    S3_Scared
+    S3_Scared,
 }
 
 pub struct Key {
@@ -40,7 +40,7 @@ pub struct Key {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct PhaseMessage {
-    pake_v1: String
+    pake_v1: String,
 }
 
 impl Key {
@@ -55,10 +55,13 @@ impl Key {
     pub fn process(&mut self, event: KeyEvent) -> Events {
         use self::State::*;
 
-        println!("key: current state = {:?}, got event = {:?}", self.state, event);
+        println!(
+            "key: current state = {:?}, got event = {:?}",
+            self.state, event
+        );
         let (newstate, actions) = match self.state {
             S00 => self.do_S00(event),
-            S01(ref body) => { self.do_S01(body, event) },
+            S01(ref body) => self.do_S01(body, event),
             S10(ref code) => self.do_S10(&code, event),
             S11(ref code, ref body) => self.do_S11(&code, body, event),
         };
@@ -76,13 +79,17 @@ impl Key {
         let body_str = hex::decode(body).unwrap();
         println!("extract_pake_message body: {:?}", body_str);
         let pake_msg = serde_json::from_slice(&body_str)
-            .and_then(|res: PhaseMessage| {Ok(res.pake_v1)}).ok();
+            .and_then(|res: PhaseMessage| Ok(res.pake_v1))
+            .ok();
 
         pake_msg
     }
 
     fn build_pake(&self, code: &str) -> (Events, SPAKE2<Ed25519Group>) {
-        let (s1, msg1) = spake2::SPAKE2::<Ed25519Group>::start_symmetric(code.as_bytes(), self.appid.as_bytes());
+        let (s1, msg1) = spake2::SPAKE2::<Ed25519Group>::start_symmetric(
+            code.as_bytes(),
+            self.appid.as_bytes(),
+        );
         let payload = util::bytes_to_hexstr(&msg1);
         let pake_msg = PhaseMessage { pake_v1: payload };
         let pake_msg_ser = serde_json::to_vec(&pake_msg).unwrap();
@@ -96,13 +103,18 @@ impl Key {
         let versions = r#"{"app_versions": {}}"#;
         let plaintext = versions.to_string();
         let encrypted = self.encrypt_data(data_key, plaintext);
-        events![B_GotKey(key.to_vec()), M_AddMessage(phase.to_string(), encrypted), R_GotKey(key.to_vec())]
+        events![
+            B_GotKey(key.to_vec()),
+            M_AddMessage(phase.to_string(), encrypted),
+            R_GotKey(key.to_vec())
+        ]
     }
 
     fn encrypt_data(&self, key: Vec<u8>, plaintext: String) -> Vec<u8> {
         let nonce = secretbox::gen_nonce();
         let sodium_key = secretbox::Key::from_slice(&key).unwrap();
-        let ciphertext = secretbox::seal(plaintext.as_bytes(), &nonce, &sodium_key);
+        let ciphertext =
+            secretbox::seal(plaintext.as_bytes(), &nonce, &sodium_key);
         ciphertext
     }
 
@@ -115,9 +127,12 @@ impl Key {
     fn derive_phase_key(&self, key: &[u8], phase: String) -> Vec<u8> {
         let side_bytes = self.side.as_bytes();
         let phase_bytes = phase.as_bytes();
-        let side_digest: Vec<u8> = self.sha256_digest(side_bytes).iter().cloned().collect();
-        let phase_digest: Vec<u8> = self.sha256_digest(phase_bytes).iter().cloned().collect();
-        let mut purpose_vec: Vec<u8> = "wormhole:phase:".as_bytes().iter().cloned().collect();
+        let side_digest: Vec<u8> =
+            self.sha256_digest(side_bytes).iter().cloned().collect();
+        let phase_digest: Vec<u8> =
+            self.sha256_digest(phase_bytes).iter().cloned().collect();
+        let mut purpose_vec: Vec<u8> =
+            "wormhole:phase:".as_bytes().iter().cloned().collect();
         purpose_vec.extend(side_digest);
         purpose_vec.extend(phase_digest);
 
@@ -133,11 +148,11 @@ impl Key {
             GotCode(code) => {
                 // defer building and sending pake.
                 (Some(State::S10(code.clone())), events![])
-            },
+            }
             GotPake(body) => {
                 // early, we haven't got the code yet.
                 (Some(State::S01(body)), events![])
-            },
+            }
             GotMessage => panic!(),
         }
     }
@@ -162,7 +177,7 @@ impl Key {
             GotCode(code) => {
                 let es = self.send_pake_compute_key(&code, &body);
                 (Some(State::S11(code, body.to_string())), es)
-            },
+            }
             GotPake(_) => panic!(),
             GotMessage => panic!(),
         }
@@ -182,7 +197,12 @@ impl Key {
     }
 
     // no state transitions while in S11, we already have got code and pake
-    fn do_S11(&self, code: &str, body: &str, event: KeyEvent) -> (Option<State>, Events) {
+    fn do_S11(
+        &self,
+        code: &str,
+        body: &str,
+        event: KeyEvent,
+    ) -> (Option<State>, Events) {
         use events::KeyEvent::*;
 
         match event {
@@ -202,7 +222,7 @@ mod test {
         use super::*;
 
         let key = super::Key::new("appid", "side1");
-        
+
         let s1 = "7b2270616b655f7631223a22353337363331646366643064336164386130346234663531643935336131343563386538626663373830646461393834373934656634666136656536306339663665227d";
         let pake_msg = key.extract_pake_msg(s1);
         assert_eq!(pake_msg, Some("537631dcfd0d3ad8a04b4f51d953a145c8e8bfc780dda984794ef4fa6ee60c9f6e".to_string()));

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -85,7 +85,7 @@ impl Key {
         let (s1, msg1) = spake2::SPAKE2::<Ed25519Group>::start_symmetric(code.as_bytes(), self.appid.as_bytes());
         let payload = util::bytes_to_hexstr(&msg1);
         let pake_msg = PhaseMessage { pake_v1: payload };
-        let pake_msg_ser = serde_json::to_string(&pake_msg).unwrap();
+        let pake_msg_ser = serde_json::to_vec(&pake_msg).unwrap();
 
         (events![M_AddMessage("pake".to_string(), pake_msg_ser)], s1)
     }
@@ -96,7 +96,7 @@ impl Key {
         let versions = r#"{"app_versions": {}}"#;
         let plaintext = versions.to_string();
         let encrypted = self.encrypt_data(data_key, plaintext);
-        events![B_GotKey(key.to_vec()), M_AddMessage(phase.to_string(), util::bytes_to_hexstr(&encrypted)), R_GotKey(key.to_vec())]
+        events![B_GotKey(key.to_vec()), M_AddMessage(phase.to_string(), encrypted), R_GotKey(key.to_vec())]
     }
 
     fn encrypt_data(&self, key: Vec<u8>, plaintext: String) -> Vec<u8> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,10 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 mod events;
+extern crate spake2;
+extern crate sodiumoxide;
+extern crate sha2;
+extern crate hkdf;
 
 mod api;
 mod allocator;
@@ -57,7 +61,7 @@ impl WormholeCore {
             boss: boss::Boss::new(),
             code: code::Code::new(),
             input: input::Input::new(),
-            key: key::Key::new(),
+            key: key::Key::new(appid, side),
             lister: lister::Lister::new(),
             mailbox: mailbox::Mailbox::new(&side),
             nameplate: nameplate::Nameplate::new(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,10 +4,10 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 mod events;
-extern crate spake2;
-extern crate sodiumoxide;
-extern crate sha2;
 extern crate hkdf;
+extern crate sha2;
+extern crate sodiumoxide;
+extern crate spake2;
 
 mod api;
 mod allocator;

--- a/core/src/mailbox.rs
+++ b/core/src/mailbox.rs
@@ -6,9 +6,8 @@ use events::Event;
 // we process these
 use events::MailboxEvent;
 use events::TerminatorEvent::MailboxDone as T_MailboxDone;
-use events::RendezvousEvent::{TxOpen as RC_TxOpen,
-                              TxAdd as RC_TxAdd,
-                              TxClose as RC_TxClose};
+use events::RendezvousEvent::{TxAdd as RC_TxAdd, TxClose as RC_TxClose,
+                              TxOpen as RC_TxOpen};
 use events::NameplateEvent::Release as N_Release;
 use events::OrderEvent::GotMessage as O_GotMessage;
 // we emit these
@@ -40,9 +39,9 @@ pub struct Mailbox {
 
 enum QueueCtrl {
     Enqueue(Vec<(String, Vec<u8>)>), // append
-    Drain,                          // replace with an empty vec
-    NoAction,                       // TODO: find a better name for the field
-    AddToProcessed(String),         // add to the list of processed "phase"
+    Drain,                           // replace with an empty vec
+    NoAction,                        // TODO: find a better name for the field
+    AddToProcessed(String),          // add to the list of processed "phase"
     Dequeue(String), // remove an element from the Map given the key
 }
 
@@ -59,7 +58,10 @@ impl Mailbox {
     pub fn process(&mut self, event: MailboxEvent) -> Events {
         use self::State::*;
 
-        println!("mailbox: current state = {:?}, got event = {:?}", self.state, event);
+        println!(
+            "mailbox: current state = {:?}, got event = {:?}",
+            self.state, event
+        );
 
         let (newstate, actions, queue) = match self.state {
             S0A => self.do_S0A(event),

--- a/core/src/mailbox.rs
+++ b/core/src/mailbox.rs
@@ -6,9 +6,9 @@ use events::Event;
 // we process these
 use events::MailboxEvent;
 use events::TerminatorEvent::MailboxDone as T_MailboxDone;
-use events::RendezvousEvent::TxOpen as RC_TxOpen;
-use events::RendezvousEvent::TxAdd as RC_TxAdd;
-use events::RendezvousEvent::TxClose as RC_TxClose;
+use events::RendezvousEvent::{TxOpen as RC_TxOpen,
+                              TxAdd as RC_TxAdd,
+                              TxClose as RC_TxClose};
 use events::NameplateEvent::Release as N_Release;
 use events::OrderEvent::GotMessage as O_GotMessage;
 // we emit these
@@ -58,6 +58,8 @@ impl Mailbox {
 
     pub fn process(&mut self, event: MailboxEvent) -> Events {
         use self::State::*;
+
+        println!("mailbox: current state = {:?}, got event = {:?}", self.state, event);
 
         let (newstate, actions, queue) = match self.state {
             S0A => self.do_S0A(event),

--- a/core/src/mailbox.rs
+++ b/core/src/mailbox.rs
@@ -89,8 +89,8 @@ impl Mailbox {
             QueueCtrl::AddToProcessed(phase) => {
                 self.processed.insert(phase);
             }
-            QueueCtrl::Dequeue(key) => {
-                self.pending_outbound.remove(&key);
+            QueueCtrl::Dequeue(phase) => {
+                self.pending_outbound.remove(&phase);
             }
         }
 
@@ -260,6 +260,7 @@ impl Mailbox {
             ),
             RxMessage(side, phase, body) => {
                 if side != self.side {
+                    println!("side does not match! Theirs");
                     // theirs
                     // N_release_and_accept
                     let is_phase_in_processed = self.processed.contains(&phase);
@@ -281,6 +282,7 @@ impl Mailbox {
                     }
                 } else {
                     // ours
+                    println!("side does match! Ours");
                     (
                         Some(State::S2B(mailbox.to_string())),
                         events![],

--- a/core/src/order.rs
+++ b/core/src/order.rs
@@ -13,13 +13,13 @@ enum State {
 
 pub struct Order {
     state: State,
-    queue: Vec<(String, String, String)>
+    queue: Vec<(String, String, String)>,
 }
 
 enum QueueStatus {
     Enqueue((String, String, String)),
     Drain,
-    NoAction
+    NoAction,
 }
 
 impl Order {
@@ -33,8 +33,11 @@ impl Order {
     pub fn process(&mut self, event: OrderEvent) -> Events {
         use self::State::*;
 
-        println!("order: current state = {:?}, got event = {:?}", self.state, event);
-        
+        println!(
+            "order: current state = {:?}, got event = {:?}",
+            self.state, event
+        );
+
         let (newstate, actions, queue_status) = match self.state {
             S0 => self.do_S0(event),
             S1 => self.do_S1(event),
@@ -47,9 +50,9 @@ impl Order {
             QueueStatus::Drain => {
                 self.queue = Vec::new();
             }
-            QueueStatus::NoAction => ()
+            QueueStatus::NoAction => (),
         };
-        
+
         actions
     }
 
@@ -57,7 +60,11 @@ impl Order {
         let mut es = Events::new();
 
         for &(ref side, ref phase, ref body) in &self.queue {
-          es.push(R_GotMessage(side.to_string(), phase.to_string(), body.as_bytes().to_vec()));
+            es.push(R_GotMessage(
+                side.to_string(),
+                phase.to_string(),
+                body.as_bytes().to_vec(),
+            ));
         }
 
         es
@@ -77,9 +84,13 @@ impl Order {
                 } else {
                     // not a  pake message, queue it.
                     println!("key: not a pake message. Queue it (S0)");
-                    (State::S0, events![], QueueStatus::Enqueue((side, phase, body)))
+                    (
+                        State::S0,
+                        events![],
+                        QueueStatus::Enqueue((side, phase, body)),
+                    )
                 }
-            },
+            }
             _ => panic!(),
         }
     }
@@ -87,9 +98,11 @@ impl Order {
     fn do_S1(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
         use events::OrderEvent::*;
         match event {
-            GotMessage(side, phase, body) => {
-                (State::S1, events![R_GotMessage(side, phase, body.as_bytes().to_vec())], QueueStatus::NoAction)
-            }
+            GotMessage(side, phase, body) => (
+                State::S1,
+                events![R_GotMessage(side, phase, body.as_bytes().to_vec())],
+                QueueStatus::NoAction,
+            ),
         }
     }
 }

--- a/core/src/order.rs
+++ b/core/src/order.rs
@@ -2,18 +2,94 @@ use events::Events;
 // we process these
 use events::OrderEvent;
 // we emit these
+use events::ReceiveEvent::GotMessage as R_GotMessage;
+use events::KeyEvent::GotPake as K_GotPake;
 
-pub struct Order {}
+#[derive(Debug, PartialEq)]
+enum State {
+    S0, //no pake
+    S1, //yes pake
+}
+
+pub struct Order {
+    state: State,
+    queue: Vec<(String, String, String)>
+}
+
+enum QueueStatus {
+    Enqueue((String, String, String)),
+    Drain,
+    NoAction
+}
 
 impl Order {
     pub fn new() -> Order {
-        Order {}
+        Order {
+            state: State::S0,
+            queue: Vec::new(),
+        }
     }
 
     pub fn process(&mut self, event: OrderEvent) -> Events {
+        use self::State::*;
+
+        println!("order: current state = {:?}, got event = {:?}", self.state, event);
+        
+        let (newstate, actions, queue_status) = match self.state {
+            S0 => self.do_S0(event),
+            S1 => self.do_S1(event),
+        };
+
+        self.state = newstate;
+
+        match queue_status {
+            QueueStatus::Enqueue(tup) => self.queue.push(tup),
+            QueueStatus::Drain => {
+                self.queue = Vec::new();
+            }
+            QueueStatus::NoAction => ()
+        };
+        
+        actions
+    }
+
+    fn drain(&self) -> Events {
+        let mut es = Events::new();
+
+        for &(ref side, ref phase, ref body) in &self.queue {
+          es.push(R_GotMessage(side.to_string(), phase.to_string(), body.as_bytes().to_vec()));
+        }
+
+        es
+    }
+
+    fn do_S0(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
         use events::OrderEvent::*;
         match event {
-            GotMessage(_, _, _) => events![],
+            GotMessage(side, phase, body) => {
+                if phase == "pake" {
+                    // got a pake message
+                    println!("key: got pake message at S0");
+                    let mut es = self.drain();
+                    let mut key_events = events![K_GotPake(body)];
+                    key_events.append(&mut es);
+                    (State::S1, key_events, QueueStatus::Drain) // TODO: instead of None, return a queue status
+                } else {
+                    // not a  pake message, queue it.
+                    println!("key: not a pake message. Queue it (S0)");
+                    (State::S0, events![], QueueStatus::Enqueue((side, phase, body)))
+                }
+            },
+            _ => panic!(),
+        }
+    }
+
+    fn do_S1(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
+        use events::OrderEvent::*;
+        match event {
+            GotMessage(side, phase, body) => {
+                (State::S1, events![R_GotMessage(side, phase, body.as_bytes().to_vec())], QueueStatus::NoAction)
+            }
         }
     }
 }

--- a/core/src/order.rs
+++ b/core/src/order.rs
@@ -13,11 +13,11 @@ enum State {
 
 pub struct Order {
     state: State,
-    queue: Vec<(String, String, String)>,
+    queue: Vec<(String, String, Vec<u8>)>,
 }
 
 enum QueueStatus {
-    Enqueue((String, String, String)),
+    Enqueue((String, String, Vec<u8>)),
     Drain,
     NoAction,
 }
@@ -63,7 +63,7 @@ impl Order {
             es.push(R_GotMessage(
                 side.to_string(),
                 phase.to_string(),
-                body.as_bytes().to_vec(),
+                body.to_vec(),
             ));
         }
 
@@ -100,7 +100,7 @@ impl Order {
         match event {
             GotMessage(side, phase, body) => (
                 State::S1,
-                events![R_GotMessage(side, phase, body.as_bytes().to_vec())],
+                events![R_GotMessage(side, phase, body)],
                 QueueStatus::NoAction,
             ),
         }

--- a/core/src/receive.rs
+++ b/core/src/receive.rs
@@ -14,7 +14,9 @@ impl Receive {
     pub fn process(&mut self, event: ReceiveEvent) -> Events {
         use events::ReceiveEvent::*;
         match event {
-            GotMessage(side, phase, body) => events![B_GotMessage(side, phase, body)],
+            GotMessage(side, phase, body) => {
+                events![B_GotMessage(side, phase, body)]
+            }
             GotKey(_) => events![],
         }
     }

--- a/core/src/receive.rs
+++ b/core/src/receive.rs
@@ -14,7 +14,7 @@ impl Receive {
         use events::ReceiveEvent::*;
         match event {
             GotCode => events![],
-            GotKey => events![],
+            GotKey(_) => events![],
         }
     }
 }

--- a/core/src/receive.rs
+++ b/core/src/receive.rs
@@ -2,6 +2,7 @@ use events::Events;
 // we process these
 use events::ReceiveEvent;
 // we emit these
+use events::BossEvent::GotMessage as B_GotMessage;
 
 pub struct Receive {}
 
@@ -13,7 +14,7 @@ impl Receive {
     pub fn process(&mut self, event: ReceiveEvent) -> Events {
         use events::ReceiveEvent::*;
         match event {
-            GotCode => events![],
+            GotMessage(side, phase, body) => events![B_GotMessage(side, phase, body)],
             GotKey(_) => events![],
         }
     }

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -85,7 +85,7 @@ impl Rendezvous {
             Start => self.start(),
             TxBind(appid, side) => self.send(bind(&appid, &side)),
             TxOpen(mailbox) => self.send(open(&mailbox)),
-            TxAdd(phase, body) => self.send(add(&phase, body.as_bytes())),
+            TxAdd(phase, body) => self.send(add(&phase, &body)),
             TxClose => events![],
             Stop => self.stop(),
             TxClaim(nameplate) => self.send(claim(&nameplate)),

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -135,8 +135,8 @@ impl Rendezvous {
     }
 
     fn message_received(&mut self, _handle: WSHandle, message: &str) -> Events {
+        println!("msg is {:?}", message);
         let m = deserialize(&message);
-        println!("msg is {:?}", m);
         match m {
             Message::Claimed { mailbox } => {
                 events![N_RxClaimed(mailbox.to_string())]
@@ -145,7 +145,7 @@ impl Rendezvous {
                 side,
                 phase,
                 body,
-                id,
+                //id,
             } => events![M_RxMessage(side, phase, body)],
             _ => events![], // TODO
         }

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -136,7 +136,7 @@ impl Rendezvous {
 
     fn message_received(&mut self, _handle: WSHandle, message: &str) -> Events {
         println!("msg is {:?}", message);
-        let m = deserialize(&message);
+        let m = deserialize(message);
         match m {
             Message::Claimed { mailbox } => {
                 events![N_RxClaimed(mailbox.to_string())]
@@ -146,7 +146,7 @@ impl Rendezvous {
                 phase,
                 body,
                 //id,
-            } => events![M_RxMessage(side, phase, body)],
+            } => events![M_RxMessage(side, phase, body.as_bytes().to_vec())],
             _ => events![], // TODO
         }
     }

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -66,7 +66,7 @@ pub enum Message {
         side: String,
         phase: String,
         body: String,
-        id: String,
+        //id: String,
     },
     Close {
         mailbox: String,
@@ -326,4 +326,18 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_message() {
+        let s = r#"{"body": "7b2270616b655f7631223a22353361346566366234363434303364376534633439343832663964373236646538396462366631336632613832313537613335646562393562366237633536353533227d", "server_rx": 1523468188.293486, "id": null, "phase": "pake", "server_tx": 1523498654.753594, "type": "message", "side": "side1"}"#;
+        let m = deserialize(&s);
+        match m {
+            Message::Message {
+                side: s,
+                phase: p,
+                body: b,
+                //id: i
+            } => (),
+            _ => panic!(),
+        }
+    }
 }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,9 +1,27 @@
+use std;
+use std::str;
+
 // bytestring to hex representation of each byte as two characters.
 // so the resulting string's size is 2x the size of the input bytestring
 pub fn bytes_to_hexstr(b: &[u8]) -> String {
     let hexstr: Vec<String> = b.iter().map(|c| format!("{:02x}", c)).collect();
 
     hexstr.join("")
+}
+
+fn hex_to_char(s: &str) -> Result<char, std::num::ParseIntError> {
+    u8::from_str_radix(s, 16).map(|n| n as char)
+}
+
+pub fn hexstr_to_string(hexstr: &str) -> String {
+    let chars: Vec<&str> = hexstr.as_bytes()
+        .chunks(2)
+        .map(|ch| str::from_utf8(ch).unwrap())
+        .collect();
+
+    let s: Vec<char> = chars.iter().map(|x| hex_to_char(x).unwrap()).collect();
+
+    s.iter().collect::<String>()
 }
 
 #[cfg(test)]
@@ -17,5 +35,11 @@ mod test {
             bytes_to_hexstr(b"I am a String"),
             "4920616d206120537472696e67"
         );
+    }
+
+    #[test]
+    fn test_hexstr_to_string() {
+        let s1 = "7b2270616b655f7631223a22353337363331646366643064336164386130346234663531643935336131343563386538626663373830646461393834373934656634666136656536306339663665227d";
+        assert_eq!(hexstr_to_string(s1), "{\"pake_v1\":\"537631dcfd0d3ad8a04b4f51d953a145c8e8bfc780dda984794ef4fa6ee60c9f6e\"}");
     }
 }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -14,7 +14,8 @@ fn hex_to_char(s: &str) -> Result<char, std::num::ParseIntError> {
 }
 
 pub fn hexstr_to_string(hexstr: &str) -> String {
-    let chars: Vec<&str> = hexstr.as_bytes()
+    let chars: Vec<&str> = hexstr
+        .as_bytes()
         .chunks(2)
         .map(|ch| str::from_utf8(ch).unwrap())
         .collect();


### PR DESCRIPTION
We go much further now, however the python side fails with:
```
ERROR:  Key confirmation failed. Either you or your correspondent
typed the code wrong, or a would-be man-in-the-middle attacker guessed
incorrectly. You could try again, giving both your correspondent and
the attacker another chance.
```
On the Rust side, we get these messages. I suspect, we need to implement the `send` state machine next? 

The code needs a lot of cleanups. Just wanted to get the rsclient-send - pyclient-recv demo working and then work on cleaning things up one by one.

```
mailbox: current state = S2B("co5zidgo3c3ny"), got event = RxMessage("4dc412f47a", "pake", "7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d")
side does not match! Theirs
  out: Nameplate(Release)
  out: Order(GotMessage("4dc412f47a", "pake", "7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d"))
event: Nameplate(Release)
  out: Rendezvous(TxRelease("4"))
event: Order(GotMessage("4dc412f47a", "pake", "7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d"))
order: current state = S0, got event = GotMessage("4dc412f47a", "pake", "7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d")
key: got pake message at S0
  out: Key(GotPake("7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d"))
event: Rendezvous(TxRelease("4"))
rendezvous: TxRelease("4")
event: Key(GotPake("7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d"))
key: current state = S10("purple-sausages"), got event = GotPake("7b2270616b655f7631223a2022353364663534643964376233616662646166353963343034623331356565646535613136353534376532366363666262623238613064353736616432346430366261227d")
extract_pake_message body: "{\"pake_v1\": \"53df54d9d7b3afbdaf59c404b315eede5a165547e26ccfbbb28a0d576ad24d06ba\"}"
  out: Mailbox(AddMessage("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\""))
  out: Boss(GotKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
  out: Mailbox(AddMessage("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4"))
  out: Receive(GotKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
event: Mailbox(AddMessage("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\""))
mailbox: current state = S2B("co5zidgo3c3ny"), got event = AddMessage("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\"")
  out: Rendezvous(TxAdd("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\""))
event: Boss(GotKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
  out: API(GotUnverifiedKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
event: Mailbox(AddMessage("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4"))
mailbox: current state = S2B("co5zidgo3c3ny"), got event = AddMessage("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4")
  out: Rendezvous(TxAdd("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4"))
event: Receive(GotKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
event: Rendezvous(TxAdd("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\""))
rendezvous: TxAdd("pake", "\"53f0afb2ef1173d69666f62c15ddc7fb7bf876fc602db5ca075c94c598fef994ff\"")
  out: IO(WebSocketSendMessage(WSHandle { id: 1 }, "{\"type\":\"add\",\"phase\":\"pake\",\"body\":\"2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622\"}"))
event: API(GotUnverifiedKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184]))
event: Rendezvous(TxAdd("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4"))
rendezvous: TxAdd("version", "b69534b7ba0f0be2d57ee6f84232d9790f97f1aa643f226a0de481827cd5228ec62c4cf4")
  out: IO(WebSocketSendMessage(WSHandle { id: 1 }, "{\"type\":\"add\",\"phase\":\"version\",\"body\":\"623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634\"}"))
event: IO(WebSocketSendMessage(WSHandle { id: 1 }, "{\"type\":\"add\",\"phase\":\"pake\",\"body\":\"2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622\"}"))
event: IO(WebSocketSendMessage(WSHandle { id: 1 }, "{\"type\":\"add\",\"phase\":\"version\",\"body\":\"623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634\"}"))
action GotUnverifiedKey([156, 139, 207, 155, 161, 62, 165, 253, 109, 158, 4, 91, 77, 160, 174, 241, 187, 97, 155, 146, 194, 92, 236, 66, 108, 110, 22, 185, 254, 58, 26, 184])
sending "{\"type\":\"add\",\"phase\":\"pake\",\"body\":\"2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622\"}"
sending "{\"type\":\"add\",\"phase\":\"version\",\"body\":\"623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634\"}"
got message {"server_tx": 1523884193.798424, "type": "ack", "id": null}
msg is "{\"server_tx\": 1523884193.798424, \"type\": \"ack\", \"id\": null}"
got message {"body": "2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622", "server_rx": 1523884193.798387, "id": null, "phase": "pake", "server_tx": 1523884193.801929, "type": "message", "side": "side1"}
msg is "{\"body\": \"2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622\", \"server_rx\": 1523884193.798387, \"id\": null, \"phase\": \"pake\", \"server_tx\": 1523884193.801929, \"type\": \"message\", \"side\": \"side1\"}"
event: Mailbox(RxMessage("side1", "pake", "2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622"))
mailbox: current state = S2B("co5zidgo3c3ny"), got event = RxMessage("side1", "pake", "2235336630616662326566313137336436393636366636326331356464633766623762663837366663363032646235636130373563393463353938666566393934666622")
side does match! Ours
got message {"server_tx": 1523884193.802097, "type": "ack", "id": null}
msg is "{\"server_tx\": 1523884193.802097, \"type\": \"ack\", \"id\": null}"
got message {"body": "623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634", "server_rx": 1523884193.802085, "id": null, "phase": "version", "server_tx": 1523884193.805114, "type": "message", "side": "side1"}
msg is "{\"body\": \"623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634\", \"server_rx\": 1523884193.802085, \"id\": null, \"phase\": \"version\", \"server_tx\": 1523884193.805114, \"type\": \"message\", \"side\": \"side1\"}"
event: Mailbox(RxMessage("side1", "version", "623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634"))
mailbox: current state = S2B("co5zidgo3c3ny"), got event = RxMessage("side1", "version", "623639353334623762613066306265326435376565366638343233326439373930663937663161613634336632323661306465343831383237636435323238656336326334636634")
side does match! Ours
```