### PR TITLE
WIP: Input machine implementation

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,3 +19,4 @@ rustc-serialize = "0.3"
 [dev-dependencies]
 ws = "0.7"
 url = "1.7"
+rustyline = "1.0"

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -38,13 +38,14 @@ impl ws::Factory for Factory {
     }
 }
 
-struct CodeCompleter {
+struct CodeCompleter<'a> {
     wcr: Rc<RefCell<WormholeCore>>,
+    out: &'a ws::Sender,
 }
 
 static BREAK_CHARS: [char; 1] = [' '];
 
-impl Completer for CodeCompleter {
+impl<'a> Completer for CodeCompleter<'a> {
     fn complete(
         &self,
         line: &str,
@@ -53,7 +54,8 @@ impl Completer for CodeCompleter {
         let (start, word) =
             extract_word(line, pos, &BREAK_CHARS.iter().cloned().collect());
         let mut wc = self.wcr.borrow_mut();
-        let completions = wc.get_completions(word);
+        let (actions, completions) = wc.get_completions(word);
+        process_actions(&self.out, actions);
         Ok((start, completions))
     }
 }

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -1,0 +1,170 @@
+extern crate magic_wormhole_core;
+extern crate rustyline;
+#[macro_use]
+extern crate serde_json;
+extern crate url;
+extern crate ws;
+
+use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
+                          TimerHandle, WSHandle, WormholeCore};
+
+use std::cell::{RefCell, RefMut};
+use std::rc::Rc;
+use url::Url;
+use rustyline::completion::{extract_word, Completer};
+
+const MAILBOX_SERVER: &'static str = "ws://localhost:4000/v1";
+const APPID: &'static str = "lothar.com/wormhole/text-or-file-xfer";
+
+struct Factory {
+    wsh: WSHandle,
+    wcr: Rc<RefCell<WormholeCore>>,
+}
+
+struct WSHandler {
+    wsh: WSHandle,
+    wcr: Rc<RefCell<WormholeCore>>,
+    out: ws::Sender,
+}
+
+impl ws::Factory for Factory {
+    type Handler = WSHandler;
+    fn connection_made(&mut self, out: ws::Sender) -> WSHandler {
+        WSHandler {
+            wsh: self.wsh,
+            wcr: Rc::clone(&self.wcr),
+            out: out,
+        }
+    }
+}
+
+struct CodeCompleter {
+    wcr: Rc<RefCell<WormholeCore>>,
+}
+
+static BREAK_CHARS: [char; 1] = [' '];
+
+impl Completer for CodeCompleter {
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+    ) -> rustyline::Result<(usize, Vec<String>)> {
+        let (start, word) =
+            extract_word(line, pos, &BREAK_CHARS.iter().cloned().collect());
+        let mut wc = self.wcr.borrow_mut();
+        let completions = wc.get_completions(word);
+        Ok((start, completions))
+    }
+}
+
+impl ws::Handler for WSHandler {
+    fn on_open(&mut self, _: ws::Handshake) -> Result<(), ws::Error> {
+        println!("On_open");
+        let mut wc = self.wcr.borrow_mut();
+        let actions = wc.do_io(IOEvent::WebSocketConnectionMade(self.wsh));
+        // TODO: This is for experiment we are starting the Input machine
+        // manually
+        let actions = wc.do_api(APIEvent::InputCode);
+        process_actions(&self.out, actions);
+
+        let completer = CodeCompleter {
+            wcr: Rc::clone(&self.wcr),
+        };
+
+        let mut rl = rustyline::Editor::new();
+        rl.set_completer(Some(completer));
+        loop {
+            match rl.readline("Enter receive wormhole code: ") {
+                Ok(line) => {
+                    if line.trim().is_empty() {
+                        // Wait till user enter the code
+                        continue;
+                    }
+
+                    // We got full code lets inform input about it.
+                    let actions = wc.do_api(APIEvent::HelperChoseWord(line));
+                    process_actions(&self.out, actions);
+                    break;
+                }
+                Err(rustyline::error::ReadlineError::Interrupted) => {
+                    println!("Interrupted");
+                    continue;
+                }
+                Err(rustyline::error::ReadlineError::Eof) => {
+                    break;
+                }
+                Err(err) => {
+                    println!("Error: {:?}", err);
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn on_message(&mut self, msg: ws::Message) -> Result<(), ws::Error> {
+        println!("got message {}", msg);
+        let mut wc = self.wcr.borrow_mut();
+        let text = msg.as_text()?.to_string();
+        let rx = IOEvent::WebSocketMessageReceived(self.wsh, text);
+        let actions = wc.do_io(rx);
+        process_actions(&self.out, actions);
+        Ok(())
+    }
+}
+
+fn process_actions(out: &ws::Sender, actions: Vec<Action>) {
+    for a in actions {
+        match a {
+            Action::IO(io) => match io {
+                IOAction::WebSocketSendMessage(_wsh, msg) => {
+                    println!("sending {:?}", msg);
+                    out.send(msg).unwrap();
+                }
+                IOAction::WebSocketClose(_wsh) => {
+                    out.close(ws::CloseCode::Normal).unwrap();
+                }
+                _ => {
+                    println!("action: {:?}", io);
+                }
+            },
+            Action::API(api) => match api {
+                APIAction::GotMessage(msg) => println!(
+                    "API Got Message: {}",
+                    String::from_utf8(msg).unwrap()
+                ),
+                _ => println!("action {:?}", api),
+            },
+        }
+    }
+}
+
+fn main() {
+    println!("Receive start");
+
+    let mut wc = WormholeCore::new(APPID, MAILBOX_SERVER);
+    let wsh;
+    let ws_url;
+    let mut actions = wc.start();
+
+    if let Action::IO(IOAction::WebSocketOpen(handle, url)) =
+        actions.pop().unwrap()
+    {
+        wsh = handle;
+        ws_url = Url::parse(&url).unwrap();
+    } else {
+        panic!();
+    }
+
+    let f = Factory {
+        wsh: wsh,
+        wcr: Rc::new(RefCell::new(wc)),
+    };
+
+    let b = ws::Builder::new();
+    let mut w1 = b.build(f).unwrap();
+    w1.connect(ws_url).unwrap();
+    w1.run().unwrap();
+}

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[derive(Debug, PartialEq)]
 pub enum APIEvent {
     // from application to IO glue to WormholeCore
     AllocateCode,

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -4,6 +4,7 @@ pub enum APIEvent {
     // from application to IO glue to WormholeCore
     AllocateCode,
     InputCode,
+    HelperChoseWord(String),
     SetCode(String),
     Close,
     Send(Vec<u8>),

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -10,6 +10,7 @@ use events::CodeEvent::{AllocateCode as C_AllocateCode,
 use events::RendezvousEvent::Stop as RC_Stop;
 use events::SendEvent::Send as S_Send;
 use events::TerminatorEvent::Close as T_Close;
+use events::InputEvent::ChooseWords as I_ChooseWords;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum State {
@@ -53,6 +54,7 @@ impl Boss {
             AllocateCode => self.allocate_code(), // TODO: len, wordlist
             InputCode => self.input_code(),       // TODO: return Helper
             SetCode(code) => self.set_code(&code),
+            HelperChoseWord(word) => self.choose_word(&word),
             Close => events![RC_Stop], // eventually signals GotClosed
             Send(plaintext) => self.send(plaintext),
         }
@@ -95,6 +97,16 @@ impl Boss {
             // same flow for allocate_code and input_code
             Empty(i) => (events![C_SetCode(code.to_string())], Coding(i)),
             _ => panic!(), // TODO: signal AlreadyStartedCodeError
+        };
+        self.state = newstate;
+        actions
+    }
+
+    fn choose_word(&mut self, word: &str) -> Events {
+        use self::State::*;
+        let (actions, newstate) = match self.state {
+            Coding(i) => (events![I_ChooseWords(word.to_string())], Coding(i)),
+            _ => panic!(),
         };
         self.state = newstate;
         actions

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -55,6 +55,11 @@ pub enum InputEvent {
     ChooseNameplate(String),
     ChooseWords(String),
     RefreshNameplates,
+
+    // These 2 are specifically for the input helper for generating during tab
+    // completions
+    GetNameplateCompletions(String),
+    GetWordCompletions(String),
 }
 
 #[derive(Debug, PartialEq)]

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -55,11 +55,15 @@ pub enum InputEvent {
     ChooseNameplate(String),
     ChooseWords(String),
     RefreshNameplates,
+}
 
-    // These 2 are specifically for the input helper for generating during tab
-    // completions
-    GetNameplateCompletions(String),
-    GetWordCompletions(String),
+#[derive(Debug, PartialEq)]
+pub enum InputHelperEvent {
+    RefreshNameplates,
+    GotNameplates(Vec<String>),
+    GotWordlist(Wordlist),
+    ChooseNameplate(String),
+    ChooseWords(String),
 }
 
 #[derive(Debug, PartialEq)]
@@ -165,6 +169,7 @@ pub enum Event {
     Boss(BossEvent),
     Code(CodeEvent),
     Input(InputEvent),
+    InputHelper(InputHelperEvent),
     Key(KeyEvent),
     Lister(ListerEvent),
     Mailbox(MailboxEvent),
@@ -211,6 +216,12 @@ impl From<CodeEvent> for Event {
 impl From<InputEvent> for Event {
     fn from(r: InputEvent) -> Self {
         Event::Input(r)
+    }
+}
+
+impl From<InputHelperEvent> for Event {
+    fn from(r: InputHelperEvent) -> Self {
+        Event::InputHelper(r)
     }
 }
 

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -50,8 +50,11 @@ pub enum CodeEvent {
 #[derive(Debug, PartialEq)]
 pub enum InputEvent {
     Start,
-    GotNameplates,
-    GotWordlist,
+    GotNameplates(Vec<String>),
+    GotWordlist(Wordlist),
+    ChooseNameplate(String),
+    ChooseWords(String),
+    RefreshNameplates,
 }
 
 #[derive(Debug, PartialEq)]

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -65,7 +65,7 @@ pub enum KeyEvent {
 pub enum ListerEvent {
     Connected,
     Lost,
-    RxNameplates,
+    RxNameplates(Vec<String>),
     Refresh,
 }
 

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -95,7 +95,9 @@ impl Input {
 
     fn in_type_with_wordlist(&mut self, event: InputEvent) -> (State, Events) {
         match event {
-            GotNameplates(..) => (self.state, events![]),
+            GotNameplates(nameplates) => {
+                (self.state, events![IH_GotNameplates(nameplates)])
+            }
             ChooseWords(words) => {
                 let code = format!{"{}-{}", self._nameplate, words};
                 (State::S4_done, events![C_FinishedInput(code)])

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -1,7 +1,8 @@
 use events::Events;
 // we process these
-use events::InputEvent::{self, ChooseNameplate, ChooseWords, GotNameplates,
-                         GotWordlist, RefreshNameplates, Start};
+use events::InputEvent::{self, ChooseNameplate, ChooseWords,
+                         GetNameplateCompletions, GetWordCompletions,
+                         GotNameplates, GotWordlist, RefreshNameplates, Start};
 // we emit these
 use events::ListerEvent::Refresh as L_Refresh;
 use events::CodeEvent::{FinishedInput as C_FinishedInput,
@@ -67,6 +68,11 @@ impl Input {
                 )
             }
             RefreshNameplates => (self.state, events![L_Refresh]),
+            GetNameplateCompletions(prefix) => {
+                // TODO: How do we send back set of possible nameplates back to
+                // caller? and do we need to generate any events?
+                (self.state, events![])
+            }
             _ => (self.state, events![]),
         }
     }
@@ -87,6 +93,11 @@ impl Input {
                 let code = format!("{}-{}", self._nameplate, words);
                 (State::S4_done, events![C_FinishedInput(code)])
             }
+            GetWordCompletions(prefix) => {
+                // TODO: We can't do any word completions here we should raise
+                // error as this should not happen.
+                (self.state, events![])
+            }
             _ => (self.state, events![]),
         }
     }
@@ -97,6 +108,11 @@ impl Input {
             ChooseWords(words) => {
                 let code = format!{"{}-{}", self._nameplate, words};
                 (State::S4_done, events![C_FinishedInput(code)])
+            }
+            GetWordCompletions(prefix) => {
+                // TODO: Here we need to use wordlist to create possible set of
+                // completions based on user input but how do we pass it to user?
+                (self.state, events![])
             }
             _ => (self.state, events![]),
         }

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -32,14 +32,15 @@ impl Input {
     }
 
     pub fn process(&mut self, event: InputEvent) -> Events {
+        use self::State::*;
         let (newstate, actions) = match self.state {
-            S0_idle => self.in_idle(event),
+            S0_Idle => self.in_idle(event),
             S1_typing_nameplate => self.in_typing_nameplate(event),
             S2_typing_code_without_wordlist => {
                 self.in_type_without_wordlist(event)
             }
             S3_typing_code_with_wordlist => self.in_type_with_wordlist(event),
-            S4_done => (self.state, events![]),
+            State::S4_done => (self.state, events![]),
         };
 
         self.state = newstate;

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -1,21 +1,104 @@
 use events::Events;
 // we process these
-use events::InputEvent;
+use events::InputEvent::{self, ChooseNameplate, ChooseWords, GotNameplates,
+                         GotWordlist, RefreshNameplates, Start};
 // we emit these
+use events::ListerEvent::Refresh as L_Refresh;
+use events::CodeEvent::{FinishedInput as C_FinishedInput,
+                        GotNameplate as C_GotNameplate};
 
-pub struct Input {}
+pub struct Input {
+    state: State,
+    _all_nameplates: Vec<String>,
+    _nameplate: String,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum State {
+    S0_Idle,
+    S1_typing_nameplate,
+    S2_typing_code_without_wordlist,
+    S3_typing_code_with_wordlist,
+    S4_done,
+}
 
 impl Input {
     pub fn new() -> Input {
-        Input {}
+        Input {
+            state: State::S0_Idle,
+            _all_nameplates: Vec::new(),
+            _nameplate: String::new(),
+        }
     }
 
     pub fn process(&mut self, event: InputEvent) -> Events {
-        use events::InputEvent::*;
+        let (newstate, actions) = match self.state {
+            S0_idle => self.in_idle(event),
+            S1_typing_nameplate => self.in_typing_nameplate(event),
+            S2_typing_code_without_wordlist => {
+                self.in_type_without_wordlist(event)
+            }
+            S3_typing_code_with_wordlist => self.in_type_with_wordlist(event),
+            S4_done => (self.state, events![]),
+        };
+
+        self.state = newstate;
+        actions
+    }
+
+    fn in_idle(&mut self, event: InputEvent) -> (State, Events) {
         match event {
-            Start => events![],
-            GotNameplates => events![],
-            GotWordlist => events![],
+            Start => (State::S1_typing_nameplate, events![L_Refresh]),
+            _ => (self.state, events![]),
+        }
+    }
+
+    fn in_typing_nameplate(&mut self, event: InputEvent) -> (State, Events) {
+        match event {
+            GotNameplates(nameplates) => {
+                self._all_nameplates = nameplates;
+                (State::S1_typing_nameplate, events![])
+            }
+            ChooseNameplate(nameplate) => {
+                self._nameplate = nameplate.to_owned();
+                (
+                    State::S2_typing_code_without_wordlist,
+                    events![C_GotNameplate(nameplate)],
+                )
+            }
+            RefreshNameplates => (self.state, events![L_Refresh]),
+            _ => (self.state, events![]),
+        }
+    }
+
+    fn in_type_without_wordlist(
+        &mut self,
+        event: InputEvent,
+    ) -> (State, Events) {
+        match event {
+            GotNameplates(nameplates) => {
+                self._all_nameplates = nameplates;
+                (State::S2_typing_code_without_wordlist, events![])
+            }
+            GotWordlist(wordlist) => {
+                (State::S3_typing_code_with_wordlist, events![])
+            }
+            ChooseWords(words) => {
+                let code = format!("{}-{}", self._nameplate, words);
+                (State::S4_done, events![C_FinishedInput(code)])
+            }
+            _ => (self.state, events![]),
+        }
+    }
+
+    fn in_type_with_wordlist(&mut self, event: InputEvent) -> (State, Events) {
+        match event {
+            GotNameplates(..) => (self.state, events![]),
+            ChooseWords(words) => {
+                let code = format!{"{}-{}", self._nameplate, words};
+                (State::S4_done, events![C_FinishedInput(code)])
+            }
+            _ => (self.state, events![]),
         }
     }
 }

--- a/core/src/inputhelper.rs
+++ b/core/src/inputhelper.rs
@@ -7,7 +7,8 @@ use events::InputHelperEvent::{self, ChooseNameplate, ChooseWords,
 // We emit the following events
 use events::InputEvent::{ChooseNameplate as I_ChooseNameplate,
                          ChooseWords as I_ChooseWords,
-                         RefreshNameplates as I_RefreshNameplates};
+                         RefreshNameplates as I_RefreshNameplates,
+                         Start as I_Start};
 
 pub struct InputHelper {
     _all_nameplates: Option<Vec<String>>,
@@ -73,7 +74,7 @@ impl InputHelper {
                 (events![], completions)
             } else {
                 // TODO: might not be correct needs fixing.
-                (events![I_RefreshNameplates], Vec::new())
+                (events![I_Start, I_RefreshNameplates], Vec::new())
             }
         }
     }

--- a/core/src/inputhelper.rs
+++ b/core/src/inputhelper.rs
@@ -1,5 +1,6 @@
 use events::{Events, Wordlist};
 use wordlist::PGPWordlist;
+use std::collections::HashSet;
 // We process these events
 use events::InputHelperEvent::{self, ChooseNameplate, ChooseWords,
                                GotNameplates, GotWordlist, RefreshNameplates};
@@ -53,19 +54,27 @@ impl InputHelper {
 
             // We have already the nameplate hence we need to emit event telling
             // input machine about nameplate
-            let completions: Vec<String> =
-                self.get_word_completions(words).iter().collect();
+            // let completions: Vec<_> =
+            //     self.get_word_completions(&words).iter().collect();
             (
                 events![I_ChooseNameplate(nameplate.to_string())],
-                completions.iter().map(|w| nameplate + "-" + w).collect(),
+                self.get_word_completions(&words)
+                    .iter()
+                    .map(|w| nameplate.to_string() + "-" + w)
+                    .collect(),
             )
         } else {
-            let completions: Vec<String> = self._all_nameplates
-                .iter()
-                .filter(|n| n.starts_with(prefix))
-                .map(|n| n + "-")
-                .collect();
-            (events![], completions)
+            if let Some(ref _all_nameplates) = self._all_nameplates {
+                let completions: Vec<String> = _all_nameplates
+                    .iter()
+                    .filter(|n| n.starts_with(prefix))
+                    .map(|n| n.to_string() + "-")
+                    .collect();
+                (events![], completions)
+            } else {
+                // TODO: might not be correct needs fixing.
+                (events![I_RefreshNameplates], Vec::new())
+            }
         }
     }
 }

--- a/core/src/inputhelper.rs
+++ b/core/src/inputhelper.rs
@@ -1,0 +1,71 @@
+use events::{Events, Wordlist};
+use wordlist::PGPWordlist;
+// We process these events
+use events::InputHelperEvent::{self, ChooseNameplate, ChooseWords,
+                               GotNameplates, GotWordlist, RefreshNameplates};
+// We emit the following events
+use events::InputEvent::{ChooseNameplate as I_ChooseNameplate,
+                         ChooseWords as I_ChooseWords,
+                         RefreshNameplates as I_RefreshNameplates};
+
+pub struct InputHelper {
+    _all_nameplates: Option<Vec<String>>,
+    _wordlist: Option<Wordlist>,
+}
+
+impl InputHelper {
+    pub fn new() -> Self {
+        InputHelper {
+            _all_nameplates: None,
+            _wordlist: None,
+        }
+    }
+
+    pub fn process(&mut self, event: InputHelperEvent) -> Events {
+        match event {
+            RefreshNameplates => events![I_RefreshNameplates],
+            GotNameplates(nameplates) => {
+                self._all_nameplates = Some(nameplates);
+                events![]
+            }
+            GotWordlist(wordlist) => {
+                self._wordlist = Some(wordlist);
+                events![]
+            }
+            ChooseWords(words) => events![I_ChooseWords(words)],
+            ChooseNameplate(nameplate) => events![I_ChooseNameplate(nameplate)],
+        }
+    }
+
+    fn get_word_completions(&self, prefix: &str) -> HashSet<String> {
+        let wordlist = PGPWordlist::new();
+        wordlist.get_completions(prefix, 2)
+    }
+
+    pub fn get_completions(&self, prefix: &str) -> (Events, Vec<String>) {
+        // If we find '-' then there is a nameplate already entered
+        let got_nameplate = prefix.find('-').is_some();
+
+        if got_nameplate {
+            let ns: Vec<&str> = prefix.splitn(1, '-').collect();
+            let nameplate = ns[0];
+            let words = ns.join("");
+
+            // We have already the nameplate hence we need to emit event telling
+            // input machine about nameplate
+            let completions: Vec<String> =
+                self.get_word_completions(words).iter().collect();
+            (
+                events![I_ChooseNameplate(nameplate.to_string())],
+                completions.iter().map(|w| nameplate + "-" + w).collect(),
+            )
+        } else {
+            let completions: Vec<String> = self._all_nameplates
+                .iter()
+                .filter(|n| n.starts_with(prefix))
+                .map(|n| n + "-")
+                .collect();
+            (events![], completions)
+        }
+    }
+}

--- a/core/src/inputhelper.rs
+++ b/core/src/inputhelper.rs
@@ -49,7 +49,7 @@ impl InputHelper {
         let got_nameplate = prefix.find('-').is_some();
 
         if got_nameplate {
-            let ns: Vec<&str> = prefix.splitn(1, '-').collect();
+            let ns: Vec<&str> = prefix.splitn(2, '-').collect();
             let nameplate = ns[0];
             let words = ns.join("");
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,6 +118,18 @@ impl WormholeCore {
         Vec::new()
     }
 
+    pub fn get_completions(&mut self, prefix: &str) -> Vec<String> {
+        // We call inputhelper for name plate completions and then execute the
+        // event it returned to us. Thus we try to link inputhelper with input
+        // machine.
+        let (events, completions) = self.inputhelper.get_completions(prefix);
+
+        // TODO: This should return empty queue if not we are doing something
+        // wrong here
+        assert_eq!(self._execute(events).len(), 0);
+        completions
+    }
+
     fn _execute(&mut self, events: Events) -> Vec<Action> {
         let mut action_queue: Vec<Action> = Vec::new(); // returned
         let mut event_queue: VecDeque<Event> = VecDeque::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,7 +118,10 @@ impl WormholeCore {
         Vec::new()
     }
 
-    pub fn get_completions(&mut self, prefix: &str) -> (Vec<Action>, Vec<String>) {
+    pub fn get_completions(
+        &mut self,
+        prefix: &str,
+    ) -> (Vec<Action>, Vec<String>) {
         // We call inputhelper for name plate completions and then execute the
         // event it returned to us. Thus we try to link inputhelper with input
         // machine.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,16 +118,15 @@ impl WormholeCore {
         Vec::new()
     }
 
-    pub fn get_completions(&mut self, prefix: &str) -> Vec<String> {
+    pub fn get_completions(&mut self, prefix: &str) -> (Vec<Action>, Vec<String>) {
         // We call inputhelper for name plate completions and then execute the
         // event it returned to us. Thus we try to link inputhelper with input
         // machine.
         let (events, completions) = self.inputhelper.get_completions(prefix);
 
-        // TODO: This should return empty queue if not we are doing something
-        // wrong here
-        assert_eq!(self._execute(events).len(), 0);
-        completions
+        // TODO: We might get some actions how do we communicate it with app?
+        let actions = self._execute(events);
+        (actions, completions)
     }
 
     fn _execute(&mut self, events: Events) -> Vec<Action> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@ mod allocator;
 mod boss;
 mod code;
 mod input;
+mod inputhelper;
 mod key;
 mod lister;
 mod mailbox;
@@ -45,6 +46,7 @@ pub struct WormholeCore {
     boss: boss::Boss,
     code: code::Code,
     input: input::Input,
+    inputhelper: inputhelper::InputHelper,
     key: key::Key,
     lister: lister::Lister,
     mailbox: mailbox::Mailbox,
@@ -75,6 +77,7 @@ impl WormholeCore {
             boss: boss::Boss::new(),
             code: code::Code::new(),
             input: input::Input::new(),
+            inputhelper: inputhelper::InputHelper::new(),
             key: key::Key::new(appid, side.as_str()),
             lister: lister::Lister::new(),
             mailbox: mailbox::Mailbox::new(&side),
@@ -137,6 +140,7 @@ impl WormholeCore {
                 Boss(e) => self.boss.process(e),
                 Code(e) => self.code.process(e),
                 Input(e) => self.input.process(e),
+                InputHelper(e) => self.inputhelper.process(e),
                 Key(e) => self.key.process(e),
                 Lister(e) => self.lister.process(e),
                 Mailbox(e) => self.mailbox.process(e),

--- a/core/src/lister.rs
+++ b/core/src/lister.rs
@@ -56,7 +56,9 @@ impl Lister {
         match event {
             Refresh => (State::S1B, events![RC_TxList]),
             Lost => (State::S0A, events![]),
-            RxNameplates => (State::S0B, events![I_GotNameplates]),
+            RxNameplates(nids) => {
+                (State::S0B, events![I_GotNameplates(nids.clone())])
+            }
             Connected => (State::S0B, events![]),
         }
     }
@@ -73,7 +75,9 @@ impl Lister {
         match event {
             Lost => (State::S1A, events![]),
             Refresh => (State::S1B, events![RC_TxList]),
-            RxNameplates => (State::S0B, events![I_GotNameplates]),
+            RxNameplates(nids) => {
+                (State::S0B, events![I_GotNameplates(nids.clone())])
+            }
             Connected => (State::S1B, events![]),
         }
     }
@@ -98,7 +102,10 @@ mod test {
         assert_eq!(lister.state, State::S0A);
 
         lister.state = State::S0B;
-        assert_eq!(lister.process(RxNameplates), events![GotNameplates]);
+        assert_eq!(
+            lister.process(RxNameplates(vec!["3".to_string()])),
+            events![GotNameplates(vec!["3".to_string()])]
+        );
         assert_eq!(lister.state, State::S0B);
 
         assert_eq!(lister.process(Refresh), events![TxList]);

--- a/core/src/nameplate.rs
+++ b/core/src/nameplate.rs
@@ -1,4 +1,4 @@
-use events::Events;
+use events::{Events, Wordlist};
 // we process these
 use events::NameplateEvent;
 // we emit these
@@ -154,7 +154,7 @@ impl Nameplate {
             RxClaimed(mailbox) => (
                 Some(State::S3B(nameplate.to_string())),
                 events![
-                    I_GotWordlist, // TODO: ->wordlist
+                    I_GotWordlist(Wordlist {}), // TODO: ->Wordlist is just placeholder should use PGPWordList instead I guess
                     M_GotMailbox(mailbox)
                 ],
             ),

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -24,7 +24,8 @@ use events::NameplateEvent::{Connected as N_Connected,
 use events::AllocatorEvent::{Connected as A_Connected,
                              RxAllocated as A_RxAllocated};
 use events::MailboxEvent::{Connected as M_Connected, RxMessage as M_RxMessage};
-use events::ListerEvent::Connected as L_Connected;
+use events::ListerEvent::{Connected as L_Connected,
+                          RxNameplates as L_RxNamePlates};
 use events::RendezvousEvent::TxBind as RC_TxBind; // loops around
 
 #[derive(Debug, PartialEq)]
@@ -157,6 +158,11 @@ impl Rendezvous {
             } => events![M_RxMessage(side, phase, hex::decode(body).unwrap())],
             Message::Allocated { nameplate } => {
                 events![A_RxAllocated(nameplate)]
+            }
+            Message::Nameplates { nameplates } => {
+                let nids: Vec<String> =
+                    nameplates.iter().map(|n| n.id.to_owned()).collect();
+                events![L_RxNamePlates(nids)]
             }
             _ => events![], // TODO
         }

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -5,12 +5,12 @@ use util;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Nameplate {
-    id: String,
+    pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct WelcomeMsg {
-    motd: String,
+    pub motd: String,
 }
 
 // convert an optional field (which may result in deserialization error)


### PR DESCRIPTION
This is an attempt to port Input machine as per python magic-wormhole code. But this is not complete as it gave out several questions which needs answering.

1. We do not need another helper object as in python code, at least that is what I feel. One reason for this is unlike python code we only emit events and no IO is performed on our side. Also in python code helper is passed to rlcompleter class to trigger event that leads to return of completions. I think with some thinking we can do that in Input struct itself.
2. I've added 2 events specifically for tab completions this should be triggered only when user hits tab. But I'm unsure how we communicate back the results to completer. May be new IO Events?.

I looked at rustyline, which was suggested crate in one of the comments in #24. I see one possibility is to make Input machine implement the `Completer` trait and let it internally check for the state and depending on user input and state of the machine it returns appropriate results. This will avoid the tab completions to interact or affect the Input state machine itself.  But given that we follow sans-io approach relying on a specific I/O crate might not feel like correct. I also checked most other available crates for readline implementation and all of them needs implementation of trait like `Completer` in rustyline, only with different input and output value.

At the moment I'm bit lost. I've all what is needed to do the completion but I don't know how to really go further :-). 

@warner @vu3rdd can you please share your thoughts?.