### PR TITLE
Clear all compile time warnings

### DIFF
--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -1,16 +1,14 @@
 extern crate magic_wormhole_core;
 extern crate rustyline;
-#[macro_use]
 extern crate serde_json;
 extern crate url;
 extern crate ws;
 
 use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
-                          TimerHandle, WSHandle, WormholeCore};
+                          WSHandle, WormholeCore};
 
 use std::sync::{Arc, Mutex, mpsc::{channel, Sender}};
-use std::thread::{sleep, spawn};
-use std::time::Duration;
+use std::thread::spawn;
 
 use rustyline::completion::{extract_word, Completer};
 use url::Url;
@@ -88,7 +86,7 @@ impl ws::Handler for WSHandler {
         };
 
         let (tx, rx) = channel();
-        let handle = spawn(move || {
+        spawn(move || {
             let mut rl = rustyline::Editor::new();
             rl.set_completer(Some(completer));
             loop {
@@ -110,7 +108,7 @@ impl ws::Handler for WSHandler {
                         break;
                     }
                     Err(err) => {
-                        // println!("Error: {:?}", err);
+                        println!("Error: {:?}", err);
                         break;
                     }
                 }
@@ -118,12 +116,10 @@ impl ws::Handler for WSHandler {
         });
 
         let out_actions = self.out.clone();
-        let amwc = Arc::clone(&self.wcr);
 
         spawn(move || {
             for actions in rx_action {
                 // println!("{:?}", actions);
-                let mut wc = amwc.lock().unwrap();
                 process_actions(&out_actions, actions);
             }
         });

--- a/core/examples/ws.rs
+++ b/core/examples/ws.rs
@@ -4,7 +4,7 @@ extern crate serde_json;
 extern crate url;
 extern crate ws;
 use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
-                          TimerHandle, WSHandle, WormholeCore};
+                          WSHandle, WormholeCore};
 use std::cell::RefCell;
 use std::rc::Rc;
 use url::Url;

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -1,5 +1,5 @@
 use api::Mood;
-use events::{Event, Events, Wordlist};
+use events::{Events, Wordlist};
 // we process these
 use api::APIEvent;
 use events::BossEvent;
@@ -12,6 +12,7 @@ use events::RendezvousEvent::Stop as RC_Stop;
 use events::SendEvent::Send as S_Send;
 use events::TerminatorEvent::Close as T_Close;
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum State {
     Empty(u32),
@@ -193,22 +194,15 @@ impl Boss {
         actions
     }
 
+    #[allow(dead_code)] // TODO: drop dead code directive once core is complete
     fn close(&mut self) -> Events {
         use self::State::*;
         let (actions, newstate) = match self.state {
-            Empty(i) => {
+            Empty(..) | Coding(..) | Lonely(..) => {
                 self.mood = Mood::Lonely;
                 (events![T_Close(Mood::Lonely)], Closing)
             }
-            Coding(i) => {
-                self.mood = Mood::Lonely;
-                (events![T_Close(Mood::Lonely)], Closing)
-            }
-            Lonely(i) => {
-                self.mood = Mood::Lonely;
-                (events![T_Close(Mood::Lonely)], Closing)
-            }
-            Happy(i) => {
+            Happy(..) => {
                 self.mood = Mood::Happy;
                 (events![T_Close(Mood::Happy)], Closing)
             }

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -70,9 +70,9 @@ impl Code {
                     ],
                 )
             }
-            Allocated(nameplate, code) => panic!(),
-            GotNameplate(nameplate) => panic!(),
-            FinishedInput(_code) => panic!(),
+            Allocated(..) => panic!(),
+            GotNameplate(..) => panic!(),
+            FinishedInput(..) => panic!(),
         }
     }
 
@@ -82,15 +82,15 @@ impl Code {
     ) -> (Option<State>, Events) {
         use events::CodeEvent::*;
         match event {
-            AllocateCode(_length, _wordlist) => panic!(),
+            AllocateCode(..) => panic!(),
             InputCode => panic!(),
-            SetCode(code) => panic!(),
-            Allocated(nameplate, code) => panic!(),
+            SetCode(..) => panic!(),
+            Allocated(..) => panic!(),
             GotNameplate(nameplate) => (
                 Some(State::InputtingWords),
                 events![N_SetNameplate(nameplate)],
             ),
-            FinishedInput(_code) => panic!(),
+            FinishedInput(..) => panic!(),
         }
     }
 
@@ -100,11 +100,11 @@ impl Code {
     ) -> (Option<State>, Events) {
         use events::CodeEvent::*;
         match event {
-            AllocateCode(_length, _wordlist) => panic!(),
+            AllocateCode(..) => panic!(),
             InputCode => panic!(),
-            SetCode(code) => panic!(),
-            Allocated(nameplate, code) => panic!(),
-            GotNameplate(nameplate) => panic!(),
+            SetCode(..) => panic!(),
+            Allocated(..) => panic!(),
+            GotNameplate(..) => panic!(),
             FinishedInput(code) => (
                 Some(State::Known),
                 events![
@@ -118,9 +118,9 @@ impl Code {
     fn in_allocating(&mut self, event: CodeEvent) -> (Option<State>, Events) {
         use events::CodeEvent::*;
         match event {
-            AllocateCode(_length, _wordlist) => panic!(),
+            AllocateCode(..) => panic!(),
             InputCode => panic!(),
-            SetCode(code) => panic!(),
+            SetCode(..) => panic!(),
             Allocated(nameplate, code) => {
                 // TODO: assert code.startswith(nameplate+"-")
                 (
@@ -132,20 +132,20 @@ impl Code {
                     ],
                 )
             }
-            GotNameplate(nameplate) => panic!(),
-            FinishedInput(_code) => panic!(),
+            GotNameplate(..) => panic!(),
+            FinishedInput(..) => panic!(),
         }
     }
 
     fn in_known(&mut self, event: CodeEvent) -> (Option<State>, Events) {
         use events::CodeEvent::*;
         match event {
-            AllocateCode(_length, _wordlist) => panic!(),
+            AllocateCode(..) => panic!(),
             InputCode => panic!(),
-            SetCode(code) => panic!(),
-            Allocated(nameplate, code) => panic!(),
-            GotNameplate(nameplate) => panic!(),
-            FinishedInput(_code) => panic!(),
+            SetCode(..) => panic!(),
+            Allocated(..) => panic!(),
+            GotNameplate(..) => panic!(),
+            FinishedInput(..) => panic!(),
         }
     }
 }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::str;
 // Events come into the core, Actions go out of it (to the IO glue layer)
-use api::{APIAction, APIEvent, IOAction, IOEvent, Mood, TimerHandle, WSHandle};
+use api::{APIAction, IOAction, Mood};
 
 // A unit structure only used for state machine purpose. Actual wordlist is
 // implemented by wordlist::PGPWordList.
@@ -14,7 +13,7 @@ pub struct Wordlist {}
 
 // machines (or IO, or the API) emit these events, and each is routed to a
 // specific machine (or IO or the API)
-
+#[allow(dead_code)] // TODO: Drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum AllocatorEvent {
     Allocate(u8, Wordlist),
@@ -22,7 +21,7 @@ pub enum AllocatorEvent {
     Lost,
     RxAllocated(String),
 }
-
+#[allow(dead_code)] // TODO: drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum BossEvent {
     RxWelcome,
@@ -57,6 +56,7 @@ pub enum InputEvent {
     RefreshNameplates,
 }
 
+#[allow(dead_code)] // TODO: drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum InputHelperEvent {
     RefreshNameplates,
@@ -66,6 +66,7 @@ pub enum InputHelperEvent {
     ChooseWords(String),
 }
 
+#[allow(dead_code)] // TODO: Drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum KeyEvent {
     GotCode(String),
@@ -73,6 +74,7 @@ pub enum KeyEvent {
     GotMessage,
 }
 
+#[allow(dead_code)] // TODO: drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum ListerEvent {
     Connected,
@@ -81,6 +83,7 @@ pub enum ListerEvent {
     Refresh,
 }
 
+#[allow(dead_code)] // TODO: Drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum MailboxEvent {
     Connected,
@@ -93,6 +96,7 @@ pub enum MailboxEvent {
     AddMessage(String, Vec<u8>), // PAKE+VERSION from Key, PHASE from Send
 }
 
+#[allow(dead_code)] // TODO: Drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum NameplateEvent {
     NameplateDone,
@@ -115,8 +119,6 @@ pub enum ReceiveEvent {
     GotMessage(String, String, Vec<u8>),
     GotKey(Vec<u8>),
 }
-
-use server_messages::Message;
 
 #[derive(Debug, PartialEq)]
 pub enum RendezvousEvent {
@@ -141,7 +143,7 @@ use std::fmt;
 impl fmt::Debug for SendEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &SendEvent::Send(ref phase, ref plaintext) => {
+            &SendEvent::Send(ref phase, ref _plaintext) => {
                 let p = str::from_utf8(phase.as_bytes());
                 match p {
                     Ok(p1) => write!(f, "Send({})", p1),
@@ -153,6 +155,7 @@ impl fmt::Debug for SendEvent {
     }
 }
 
+#[allow(dead_code)] // TODO: drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum TerminatorEvent {
     Close(Mood),

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -16,17 +16,17 @@ pub struct Input {
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum State {
-    S0_Idle,
-    S1_typing_nameplate,
-    S2_typing_code_without_wordlist,
-    S3_typing_code_with_wordlist,
-    S4_done,
+    S0Idle,
+    S1TypingNameplate,
+    S2TypingCodeWithoutWordlist,
+    S3TypingCodeWithWordlist,
+    S4Done,
 }
 
 impl Input {
     pub fn new() -> Input {
         Input {
-            state: State::S0_Idle,
+            state: State::S0Idle,
             _nameplate: String::new(),
         }
     }
@@ -34,13 +34,11 @@ impl Input {
     pub fn process(&mut self, event: InputEvent) -> Events {
         use self::State::*;
         let (newstate, actions) = match self.state {
-            S0_Idle => self.in_idle(event),
-            S1_typing_nameplate => self.in_typing_nameplate(event),
-            S2_typing_code_without_wordlist => {
-                self.in_type_without_wordlist(event)
-            }
-            S3_typing_code_with_wordlist => self.in_type_with_wordlist(event),
-            State::S4_done => (self.state, events![]),
+            S0Idle => self.in_idle(event),
+            S1TypingNameplate => self.in_typing_nameplate(event),
+            S2TypingCodeWithoutWordlist => self.in_type_without_wordlist(event),
+            S3TypingCodeWithWordlist => self.in_type_with_wordlist(event),
+            State::S4Done => (self.state, events![]),
         };
 
         self.state = newstate;
@@ -49,7 +47,7 @@ impl Input {
 
     fn in_idle(&mut self, event: InputEvent) -> (State, Events) {
         match event {
-            Start => (State::S1_typing_nameplate, events![L_Refresh]),
+            Start => (State::S1TypingNameplate, events![L_Refresh]),
             _ => (self.state, events![]),
         }
     }
@@ -57,13 +55,13 @@ impl Input {
     fn in_typing_nameplate(&mut self, event: InputEvent) -> (State, Events) {
         match event {
             GotNameplates(nameplates) => (
-                State::S1_typing_nameplate,
+                State::S1TypingNameplate,
                 events![IH_GotNameplates(nameplates)],
             ),
             ChooseNameplate(nameplate) => {
                 self._nameplate = nameplate.to_owned();
                 (
-                    State::S2_typing_code_without_wordlist,
+                    State::S2TypingCodeWithoutWordlist,
                     events![C_GotNameplate(nameplate)],
                 )
             }
@@ -78,16 +76,16 @@ impl Input {
     ) -> (State, Events) {
         match event {
             GotNameplates(nameplates) => (
-                State::S2_typing_code_without_wordlist,
+                State::S2TypingCodeWithoutWordlist,
                 events![IH_GotNameplates(nameplates)],
             ),
             GotWordlist(wordlist) => (
-                State::S3_typing_code_with_wordlist,
+                State::S3TypingCodeWithWordlist,
                 events![IH_GotWordlist(wordlist)],
             ),
             ChooseWords(words) => {
                 let code = format!("{}-{}", self._nameplate, words);
-                (State::S4_done, events![C_FinishedInput(code)])
+                (State::S4Done, events![C_FinishedInput(code)])
             }
             _ => (self.state, events![]),
         }
@@ -101,7 +99,7 @@ impl Input {
             ),
             ChooseWords(words) => {
                 let code = format!{"{}-{}", self._nameplate, words};
-                (State::S4_done, events![C_FinishedInput(code)])
+                (State::S4Done, events![C_FinishedInput(code)])
             }
             _ => (self.state, events![]),
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,17 +1,16 @@
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-mod events;
 extern crate hkdf;
 extern crate rand;
 extern crate rustc_serialize;
+extern crate serde_json;
 extern crate sha2;
 extern crate sodiumoxide;
 extern crate spake2;
 
+#[macro_use]
+mod events;
 mod allocator;
 mod api;
 mod boss;
@@ -33,7 +32,6 @@ mod wordlist;
 
 use rustc_serialize::hex::ToHex;
 use std::collections::VecDeque;
-use std::iter::FromIterator;
 
 use events::{Event, Events};
 use util::random_bytes;
@@ -164,7 +162,6 @@ impl WormholeCore {
                 Rendezvous(e) => self.rendezvous.process(e),
                 Send(e) => self.send.process(e),
                 Terminator(e) => self.terminator.process(e),
-                _ => panic!(),
             };
 
             for a in actions.events {

--- a/core/src/nameplate.rs
+++ b/core/src/nameplate.rs
@@ -43,17 +43,16 @@ impl Nameplate {
     pub fn process(&mut self, event: NameplateEvent) -> Events {
         use self::State::*;
         let (newstate, actions) = match self.state {
-            S0A => self.do_S0A(event),
-            S0B => self.do_S0B(event),
-            S1A(ref nameplate) => self.do_S1A(&nameplate, event),
-            S2A(ref nameplate) => self.do_S2A(&nameplate, event),
-            S2B(ref nameplate) => self.do_S2B(&nameplate, event),
-            S3A(ref nameplate) => self.do_S3A(&nameplate, event),
-            S3B(ref nameplate) => self.do_S3B(&nameplate, event),
-            S4A(ref nameplate) => self.do_S4A(&nameplate, event),
-            S4B(ref nameplate) => self.do_S4B(&nameplate, event),
-            S5 => self.do_S5(event),
-            _ => panic!(),
+            S0A => self.do_s0a(event),
+            S0B => self.do_s0b(event),
+            S1A(ref nameplate) => self.do_s1a(&nameplate, event),
+            S2A(ref nameplate) => self.do_s2a(&nameplate, event),
+            S2B(ref nameplate) => self.do_s2b(&nameplate, event),
+            S3A(ref nameplate) => self.do_s3a(&nameplate, event),
+            S3B(ref nameplate) => self.do_s3b(&nameplate, event),
+            S4A(ref nameplate) => self.do_s4a(&nameplate, event),
+            S4B(ref nameplate) => self.do_s4b(&nameplate, event),
+            S5 => self.do_s5(event),
         };
         match newstate {
             Some(s) => {
@@ -64,7 +63,7 @@ impl Nameplate {
         actions
     }
 
-    fn do_S0A(&self, event: NameplateEvent) -> (Option<State>, Events) {
+    fn do_s0a(&self, event: NameplateEvent) -> (Option<State>, Events) {
         use events::NameplateEvent::*;
         match event {
             NameplateDone => panic!(),
@@ -84,7 +83,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S0B(&self, event: NameplateEvent) -> (Option<State>, Events) {
+    fn do_s0b(&self, event: NameplateEvent) -> (Option<State>, Events) {
         use events::NameplateEvent::*;
         match event {
             NameplateDone => panic!(),
@@ -104,7 +103,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S1A(
+    fn do_s1a(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -119,13 +118,13 @@ impl Nameplate {
             Lost => panic!(),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => panic!(),
             Close => (Some(State::S5), events![T_NameplateDone]),
         }
     }
 
-    fn do_S2A(
+    fn do_s2a(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -140,7 +139,7 @@ impl Nameplate {
             Lost => panic!(),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => panic!(),
             Close => (
                 Some(State::S4A(nameplate.to_string())),
@@ -149,7 +148,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S2B(
+    fn do_s2b(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -170,7 +169,7 @@ impl Nameplate {
                 ],
             ),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => panic!(),
             Close => (
                 Some(State::S4B(nameplate.to_string())),
@@ -179,7 +178,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S3A(
+    fn do_s3a(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -194,7 +193,7 @@ impl Nameplate {
             Lost => panic!(),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => panic!(),
             Close => (
                 Some(State::S4A(nameplate.to_string())),
@@ -203,7 +202,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S3B(
+    fn do_s3b(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -218,7 +217,7 @@ impl Nameplate {
             ),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => (
                 Some(State::S4B(nameplate.to_string())),
                 events![RC_TxRelease(nameplate.to_string())],
@@ -230,7 +229,7 @@ impl Nameplate {
         }
     }
 
-    fn do_S4A(
+    fn do_s4a(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -245,13 +244,13 @@ impl Nameplate {
             Lost => (None, events![]),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => panic!(),
             Close => (None, events![]),
         }
     }
 
-    fn do_S4B(
+    fn do_s4b(
         &self,
         nameplate: &str,
         event: NameplateEvent,
@@ -269,13 +268,13 @@ impl Nameplate {
             ),
             RxClaimed(_mailbox) => (None, events![]),
             RxReleased => (Some(State::S5), events![T_NameplateDone]),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => (None, events![]),
             Close => (None, events![]),
         }
     }
 
-    fn do_S5(&self, event: NameplateEvent) -> (Option<State>, Events) {
+    fn do_s5(&self, event: NameplateEvent) -> (Option<State>, Events) {
         use events::NameplateEvent::*;
         match event {
             NameplateDone => panic!(),
@@ -283,7 +282,7 @@ impl Nameplate {
             Lost => (None, events![]),
             RxClaimed(_mailbox) => panic!(),
             RxReleased => panic!(),
-            SetNameplate(nameplate) => panic!(),
+            SetNameplate(_nameplate) => panic!(),
             Release => (None, events![]),
             Close => (None, events![]),
         }

--- a/core/src/order.rs
+++ b/core/src/order.rs
@@ -39,8 +39,8 @@ impl Order {
         );
 
         let (newstate, actions, queue_status) = match self.state {
-            S0 => self.do_S0(event),
-            S1 => self.do_S1(event),
+            S0 => self.do_s0(event),
+            S1 => self.do_s1(event),
         };
 
         self.state = newstate;
@@ -70,7 +70,7 @@ impl Order {
         es
     }
 
-    fn do_S0(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
+    fn do_s0(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
         use events::OrderEvent::*;
         match event {
             GotMessage(side, phase, body) => {
@@ -89,11 +89,10 @@ impl Order {
                     )
                 }
             }
-            _ => panic!(),
         }
     }
 
-    fn do_S1(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
+    fn do_s1(&self, event: OrderEvent) -> (State, Events, QueueStatus) {
         use events::OrderEvent::*;
         match event {
             GotMessage(side, phase, body) => (

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -1,6 +1,6 @@
 use serde_json;
 
-use serde::{self, Deserialize, Deserializer, Serializer};
+use serde::{Deserialize, Deserializer};
 use util;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -103,6 +103,8 @@ pub fn claim(nameplate: &str) -> Message {
         nameplate: nameplate.to_string(),
     }
 }
+
+#[allow(dead_code)]
 pub fn release(nameplate: &str) -> Message {
     Message::Release {
         nameplate: nameplate.to_string(),
@@ -124,6 +126,7 @@ pub fn add(phase: &str, body: &[u8]) -> Message {
     }
 }
 
+#[allow(dead_code)]
 pub fn close(mailbox: &str, mood: &str) -> Message {
     Message::Close {
         mailbox: mailbox.to_string(),
@@ -131,10 +134,12 @@ pub fn close(mailbox: &str, mood: &str) -> Message {
     }
 }
 
+#[allow(dead_code)]
 pub fn ping(ping: u32) -> Message {
     Message::Ping { ping: ping }
 }
 
+#[allow(dead_code)]
 pub fn welcome(motd: &str, timestamp: f64) -> Message {
     Message::Welcome {
         welcome: Some(WelcomeMsg {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -15,10 +15,12 @@ pub fn bytes_to_hexstr(b: &[u8]) -> String {
     hexstr.join("")
 }
 
-fn hex_to_char(s: &str) -> Result<char, std::num::ParseIntError> {
+#[allow(dead_code)] // TODO: Drop this once function is being used
+pub fn hex_to_char(s: &str) -> Result<char, std::num::ParseIntError> {
     u8::from_str_radix(s, 16).map(|n| n as char)
 }
 
+#[allow(dead_code)] // TODO: Drop this once function is being used
 pub fn hexstr_to_string(hexstr: &str) -> String {
     let chars: Vec<&str> = hexstr
         .as_bytes()

--- a/core/src/wordlist.rs
+++ b/core/src/wordlist.rs
@@ -1,4 +1,4 @@
-use serde_json::{self, from_str, Value};
+use serde_json::{self, Value};
 use std::collections::{HashMap, HashSet};
 
 use util::{bytes_to_hexstr, random_bytes};


### PR DESCRIPTION
This will help us to catch new warnings and errors in code we right easily. With
all compile warnings before useful stuff get pushed down the pile of already
existing hundreds of warnings and we miss to see warnings in our newly written code.

I've added some `#[allow(dead_code)]` in few modules, but with a **TODO** mentioning this should be dropped once the core is complete. Now since we have incomplete code these warnings will come up as most of modules are not public (`pub mod` is not used in `lib.rs`)