### PR TITLE
Use new API in readline and implement tab completion example

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,10 @@ rand = "0.4"
 rustc-serialize = "0.3"
 
 
+
 [dev-dependencies]
 ws = "0.7"
 url = "1.7"
 rustyline = "1.0"
+parking_lot = {version = "0.5", features = ["deadlock_detection"]}
+regex = "0.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,12 +14,10 @@ hkdf = "0.4.0"
 hex = "0.3"
 rand = "0.4"
 rustc-serialize = "0.3"
-
-
+regex = "0.2"
 
 [dev-dependencies]
 ws = "0.7"
 url = "1.7"
 rustyline = "1.0"
 parking_lot = {version = "0.5", features = ["deadlock_detection"]}
-regex = "0.2"

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -86,7 +86,13 @@ impl Completer for CodeCompleter {
                 drop(&wc);
 
                 match completions {
-                    Ok(completions) => Ok((0, completions)),
+                    Ok(completions) => Ok((
+                        0,
+                        completions
+                            .iter()
+                            .map(|c| format!("{}-{}", nameplate, c))
+                            .collect(),
+                    )),
                     Err(err) => Err(ReadlineError::from(io::Error::new(
                         io::ErrorKind::Other,
                         err.description(),

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use parking_lot::{deadlock, Mutex};
 use regex::Regex;
-use rustyline::{completion::{extract_word, Completer}, error::ReadlineError};
+use rustyline::{completion::Completer, error::ReadlineError};
 use url::Url;
 
 const MAILBOX_SERVER: &'static str = "ws://localhost:4000/v1";
@@ -50,13 +50,11 @@ struct CodeCompleter {
     tx_event: Sender<APIEvent>,
 }
 
-static BREAK_CHARS: [char; 1] = [' '];
-
 impl Completer for CodeCompleter {
     fn complete(
         &self,
         line: &str,
-        pos: usize,
+        _pos: usize,
     ) -> rustyline::Result<(usize, Vec<String>)> {
         let got_nameplate = line.find('-').is_some();
         let mwc = Arc::clone(&self.wcr);
@@ -65,7 +63,7 @@ impl Completer for CodeCompleter {
             let ns: Vec<_> = line.splitn(2, '-').collect();
             let nameplate = ns[0].to_string();
             let word = ns[1].to_string();
-            let mut commited_nameplate = None;
+            let commited_nameplate;
 
             {
                 let mc = mwc.lock();

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -1,4 +1,6 @@
 extern crate magic_wormhole_core;
+extern crate parking_lot;
+extern crate regex;
 extern crate rustyline;
 extern crate serde_json;
 extern crate url;
@@ -7,10 +9,15 @@ extern crate ws;
 use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
                           WSHandle, WormholeCore};
 
-use std::sync::{Arc, Mutex, mpsc::{channel, Sender}};
-use std::thread::spawn;
+use std::error::Error;
+use std::io;
+use std::sync::{Arc, mpsc::{channel, Sender}};
+use std::thread::{sleep, spawn};
+use std::time::Duration;
 
-use rustyline::completion::{extract_word, Completer};
+use parking_lot::{deadlock, Mutex};
+use regex::Regex;
+use rustyline::{completion::{extract_word, Completer}, error::ReadlineError};
 use url::Url;
 
 const MAILBOX_SERVER: &'static str = "ws://localhost:4000/v1";
@@ -40,7 +47,7 @@ impl ws::Factory for Factory {
 
 struct CodeCompleter {
     wcr: Arc<Mutex<WormholeCore>>,
-    tx: Sender<Vec<Action>>,
+    tx_event: Sender<APIEvent>,
 }
 
 static BREAK_CHARS: [char; 1] = [' '];
@@ -51,16 +58,61 @@ impl Completer for CodeCompleter {
         line: &str,
         pos: usize,
     ) -> rustyline::Result<(usize, Vec<String>)> {
-        let (start, word) = extract_word(
-            line,
-            pos,
-            &BREAK_CHARS.iter().cloned().collect(),
-        );
+        let got_nameplate = line.find('-').is_some();
         let mwc = Arc::clone(&self.wcr);
-        let mut wc = mwc.lock().unwrap();
-        let (actions, completions) = wc.get_completions(word);
-        self.tx.send(actions).unwrap();
-        Ok((start, completions))
+
+        if got_nameplate {
+            let ns: Vec<_> = line.splitn(2, '-').collect();
+            let nameplate = ns[0].to_string();
+            let word = ns[1].to_string();
+            let mut commited_nameplate = None;
+
+            {
+                let mc = mwc.lock();
+                commited_nameplate = mc.input_helper_commited_nameplate()
+                    .map(|s| s.to_string());
+            }
+
+            if commited_nameplate.is_some() {
+                if commited_nameplate.unwrap() != nameplate {
+                    return Err(ReadlineError::from(io::Error::new(
+                        io::ErrorKind::Other,
+                        "Nameplate already chosen can't go back",
+                    )));
+                }
+
+                let mut wc = mwc.lock();
+                let completions = wc.input_helper_get_word_completions(&word);
+                drop(&wc);
+
+                match completions {
+                    Ok(completions) => Ok((0, completions)),
+                    Err(err) => Err(ReadlineError::from(io::Error::new(
+                        io::ErrorKind::Other,
+                        err.description(),
+                    ))),
+                }
+            } else {
+                self.tx_event
+                    .send(APIEvent::InputHelperChooseNameplate(
+                        nameplate.clone(),
+                    ))
+                    .unwrap();
+                Ok((0, Vec::new()))
+            }
+        } else {
+            let nameplate = line.to_string();
+            let mut mc = mwc.lock();
+            let completions =
+                mc.input_helper_get_nameplate_completions(&nameplate);
+            match completions {
+                Ok(completions) => Ok((0, completions)),
+                Err(err) => Err(ReadlineError::from(io::Error::new(
+                    io::ErrorKind::Other,
+                    err.description(),
+                ))),
+            }
+        }
     }
 }
 
@@ -69,7 +121,8 @@ impl ws::Handler for WSHandler {
         // println!("On_open");
         let mwc = Arc::clone(&self.wcr);
         {
-            let mut wc = mwc.lock().unwrap();
+            println!("Initial lock on socket open");
+            let mut wc = mwc.lock();
             let actions = wc.do_io(IOEvent::WebSocketConnectionMade(self.wsh));
             process_actions(&self.out, actions);
 
@@ -77,15 +130,15 @@ impl ws::Handler for WSHandler {
             // manually
             let actions = wc.do_api(APIEvent::InputCode);
             process_actions(&self.out, actions);
+            println!("Initial lock should be dropped now");
         }
 
-        let (tx_action, rx_action) = channel();
+        let (tx_event, rx_event) = channel();
         let completer = CodeCompleter {
             wcr: Arc::clone(&self.wcr),
-            tx: tx_action,
+            tx_event: tx_event.clone(),
         };
 
-        let (tx, rx) = channel();
         spawn(move || {
             let mut rl = rustyline::Editor::new();
             rl.set_completer(Some(completer));
@@ -96,15 +149,23 @@ impl ws::Handler for WSHandler {
                             // Wait till user enter the code
                             continue;
                         }
-
-                        tx.send(line.to_string()).unwrap();
+                        let re = Regex::new(r"\d+-\w+-\w+").unwrap();
+                        if !re.is_match(&line) {
+                            panic!("Not a valid code format");
+                        }
+                        let pieces: Vec<_> = line.splitn(2, '-').collect();
+                        let words = pieces[1].to_string();
+                        tx_event
+                            .send(APIEvent::InputHelperChooseWords(words))
+                            .unwrap();
                         break;
                     }
                     Err(rustyline::error::ReadlineError::Interrupted) => {
-                        // println!("Interrupted");
+                        println!("Interrupted");
                         continue;
                     }
                     Err(rustyline::error::ReadlineError::Eof) => {
+                        println!("Got EOF");
                         break;
                     }
                     Err(err) => {
@@ -115,21 +176,12 @@ impl ws::Handler for WSHandler {
             }
         });
 
-        let out_actions = self.out.clone();
-
-        spawn(move || {
-            for actions in rx_action {
-                // println!("{:?}", actions);
-                process_actions(&out_actions, actions);
-            }
-        });
-
         let out_events = self.out.clone();
         let emwc = Arc::clone(&self.wcr);
         spawn(move || {
-            for received in rx {
-                let mut wc = emwc.lock().unwrap();
-                let actions = wc.do_api(APIEvent::HelperChoseWord(received));
+            for received in rx_event {
+                let mut wc = emwc.lock();
+                let actions = wc.do_api(received);
                 process_actions(&out_events, actions);
             }
         });
@@ -138,13 +190,15 @@ impl ws::Handler for WSHandler {
     }
 
     fn on_message(&mut self, msg: ws::Message) -> Result<(), ws::Error> {
-        // println!("got message {}", msg);
+        println!("got message {}", msg);
         let mwc = Arc::clone(&self.wcr);
         let text = msg.as_text()?.to_string();
         let rx = IOEvent::WebSocketMessageReceived(self.wsh, text);
-        let mut wc = mwc.lock().unwrap();
+
+        let mut wc = mwc.lock();
         let actions = wc.do_io(rx);
         process_actions(&self.out, actions);
+
         Ok(())
     }
 }
@@ -196,6 +250,23 @@ fn main() {
         wsh: wsh,
         wcr: Arc::new(Mutex::new(wc)),
     };
+
+    spawn(move || loop {
+        sleep(Duration::from_secs(10));
+        let deadlocks = deadlock::check_deadlock();
+        if deadlocks.is_empty() {
+            continue;
+        }
+
+        println!("{} deadlocks detected", deadlocks.len());
+        for (i, threads) in deadlocks.iter().enumerate() {
+            println!("Deadlock #{}", i);
+            for t in threads {
+                println!("Thread Id {:#?}", t.thread_id());
+                println!("{:#?}", t.backtrace());
+            }
+        }
+    });
 
     let b = ws::Builder::new();
     let mut w1 = b.build(f).unwrap();

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -1,5 +1,5 @@
 use events::{Events, Wordlist};
-use std::rc::Rc;
+use std::sync::Arc;
 
 // we process these
 use events::AllocatorEvent::{self, Allocate, Connected, Lost, RxAllocated};
@@ -15,8 +15,8 @@ pub struct Allocator {
 enum State {
     S0AIdleDisconnected,
     S0BIdleConnected,
-    S1AAllocatingDisconnected(Rc<Wordlist>),
-    S1BAllocatingConnected(Rc<Wordlist>),
+    S1AAllocatingDisconnected(Arc<Wordlist>),
+    S1BAllocatingConnected(Arc<Wordlist>),
     S2Done,
 }
 
@@ -78,7 +78,7 @@ impl Allocator {
     fn do_allocating_disconnected(
         &self,
         event: AllocatorEvent,
-        wordlist: Rc<Wordlist>,
+        wordlist: Arc<Wordlist>,
     ) -> (Option<State>, Events) {
         match event {
             Connected => (
@@ -92,7 +92,7 @@ impl Allocator {
     fn do_allocating_connected(
         &self,
         event: AllocatorEvent,
-        wordlist: Rc<Wordlist>,
+        wordlist: Arc<Wordlist>,
     ) -> (Option<State>, Events) {
         match event {
             Lost => (

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt;
 
 #[derive(Debug, PartialEq)]
@@ -20,6 +21,40 @@ pub enum InputHelperError {
     MustChooseNameplateFirst,
     AlreadyChoseNameplate,
     AlreadyChoseWords,
+}
+
+impl fmt::Display for InputHelperError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InputHelperError::Inactive => write!(f, "Inactive"),
+            InputHelperError::MustChooseNameplateFirst => {
+                write!(f, "Should Choose Nameplate first")
+            }
+            InputHelperError::AlreadyChoseNameplate => {
+                write!(f, "nameplate already chosen, can't go back")
+            }
+            InputHelperError::AlreadyChoseWords => {
+                write!(f, "Words are already chosen")
+            }
+        }
+    }
+}
+
+impl Error for InputHelperError {
+    fn description(&self) -> &str {
+        match *self {
+            InputHelperError::Inactive => "Input is not yet started",
+            InputHelperError::MustChooseNameplateFirst => {
+                "You should input name plate first!"
+            }
+            InputHelperError::AlreadyChoseNameplate => {
+                "Nameplate is already chosen, you can't go back!"
+            }
+            InputHelperError::AlreadyChoseWords => {
+                "Words are already chosen you can't go back!"
+            }
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -1,6 +1,6 @@
 use api::Mood;
 use events::Events;
-use std::rc::Rc;
+use std::sync::Arc;
 use wordlist::default_wordlist;
 
 // we process these
@@ -92,7 +92,7 @@ impl Boss {
         let (actions, newstate) = match self.state {
             Empty(i) => {
                 // TODO: provide choice of wordlists
-                let wordlist = Rc::new(default_wordlist(num_words));
+                let wordlist = Arc::new(default_wordlist(num_words));
                 (events![C_AllocateCode(wordlist)], Coding(i))
             }
             _ => panic!(), // TODO: signal AlreadyStartedCodeError

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
-use std::rc::Rc;
 use std::str;
+use std::sync::Arc;
 // Events come into the core, Actions go out of it (to the IO glue layer)
 use api::{APIAction, IOAction, Mood};
 
@@ -11,7 +11,7 @@ pub use wordlist::Wordlist;
 #[allow(dead_code)] // TODO: Drop dead code directive once core is complete
 #[derive(Debug, PartialEq)]
 pub enum AllocatorEvent {
-    Allocate(Rc<Wordlist>),
+    Allocate(Arc<Wordlist>),
     Connected,
     Lost,
     RxAllocated(String),
@@ -33,7 +33,7 @@ pub enum BossEvent {
 
 #[derive(Debug, PartialEq)]
 pub enum CodeEvent {
-    AllocateCode(Rc<Wordlist>),
+    AllocateCode(Arc<Wordlist>),
     InputCode,
     SetCode(String),
     Allocated(String, String),
@@ -47,7 +47,7 @@ pub enum InputEvent {
     ChooseNameplate(String),
     ChooseWords(String),
     GotNameplates(Vec<String>),
-    GotWordlist(Rc<Wordlist>),
+    GotWordlist(Arc<Wordlist>),
     RefreshNameplates,
 }
 

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -1,5 +1,5 @@
 use events::Events;
-use std::rc::Rc;
+use std::sync::Arc;
 // we process these
 use events::InputEvent::{self, ChooseNameplate, ChooseWords, GotNameplates,
                          GotWordlist, RefreshNameplates, Start};
@@ -21,7 +21,7 @@ enum State {
     WantNameplateNoNameplates,
     WantNameplateHaveNameplates(Vec<String>), // nameplates
     WantCodeNoWordlist(String),               // nameplate
-    WantCodeHaveWordlist(String, Rc<Wordlist>), // (nameplate, wordlist)
+    WantCodeHaveWordlist(String, Arc<Wordlist>), // (nameplate, wordlist)
     Done,
 }
 

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -12,6 +12,7 @@ use events::Wordlist;
 
 pub struct Input {
     state: State,
+    nameplate: String,
 }
 
 #[derive(Debug)]
@@ -28,6 +29,7 @@ impl Input {
     pub fn new() -> Input {
         Input {
             state: State::Idle,
+            nameplate: String::new(),
         }
     }
 
@@ -119,14 +121,17 @@ impl Input {
     }
 
     // TODO: is it possible for the wordlist to arrive before we set the nameplate?
-    fn want_nameplate(&self, event: InputEvent) -> (Option<State>, Events) {
+    fn want_nameplate(&mut self, event: InputEvent) -> (Option<State>, Events) {
         use self::State::*;
         match event {
             Start => panic!("already started"),
-            ChooseNameplate(nameplate) => (
-                Some(WantCodeNoWordlist(nameplate.clone())),
-                events![C_GotNameplate(nameplate.clone())],
-            ),
+            ChooseNameplate(nameplate) => {
+                self.nameplate = nameplate.clone();
+                (
+                    Some(WantCodeNoWordlist(nameplate.clone())),
+                    events![C_GotNameplate(nameplate.clone())],
+                )
+            }
             ChooseWords(_) => panic!("expecting nameplate, not words"),
             GotNameplates(nameplates) => (
                 Some(WantNameplateHaveNameplates(nameplates)),

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -296,7 +296,7 @@ mod test {
             vecstrings("purple green yellow"),
             vecstrings("sausages seltzer snobol"),
         ];
-        let wordlist = Rc::new(Wordlist::new(2, words));
+        let wordlist = Arc::new(Wordlist::new(2, words));
         let actions = i.process(GotWordlist(wordlist));
         assert_eq!(actions, events![]);
 

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -120,6 +120,13 @@ impl Input {
         }
     }
 
+    pub fn commited_nameplate(&self) -> Option<&str> {
+        if self.nameplate.is_empty() {
+            return None;
+        }
+        Some(&self.nameplate)
+    }
+
     // TODO: is it possible for the wordlist to arrive before we set the nameplate?
     fn want_nameplate(&mut self, event: InputEvent) -> (Option<State>, Events) {
         use self::State::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -127,6 +127,10 @@ impl WormholeCore {
         self.input.get_word_completions(prefix)
     }
 
+    pub fn input_helper_commited_nameplate(&self) -> Option<&str> {
+        self.input.commited_nameplate()
+    }
+
     fn _execute(&mut self, events: Events) -> Vec<Action> {
         let mut action_queue: Vec<Action> = Vec::new(); // returned
         let mut event_queue: VecDeque<Event> = VecDeque::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate hkdf;
 extern crate rand;
+extern crate regex;
 extern crate rustc_serialize;
 extern crate serde_json;
 extern crate sha2;

--- a/core/src/nameplate.rs
+++ b/core/src/nameplate.rs
@@ -1,5 +1,5 @@
 use events::Events;
-use std::rc::Rc;
+use std::sync::Arc;
 use wordlist::default_wordlist;
 // we process these
 use events::NameplateEvent;
@@ -165,7 +165,7 @@ impl Nameplate {
             ),
             RxClaimed(mailbox) => {
                 // TODO: use nameplate attributes to pick which wordlist we use
-                let wordlist = Rc::new(default_wordlist(2)); // TODO: num_words
+                let wordlist = Arc::new(default_wordlist(2)); // TODO: num_words
                 (
                     Some(State::S3B(nameplate.to_string())),
                     events![I_GotWordlist(wordlist), M_GotMailbox(mailbox)],


### PR DESCRIPTION
Now the readline.rs uses the new InputHelper API and successfully does the tab completion for entering code. It is also possible to receive message from python but I'm not sure if its successfully decrypted or not. 

But main idea to hook into Input machine using InputHelper api to get tab completion is now working. For this I've done couple of changes to Input machine
1. Stash the nameplate coming in from ChoseNameplate event raised from InputHelperChooseNameplate
2. input_helper_commited_nameplate method in wormhole object to access nameplate inside the Input machine which is needed by tab completion logic.

