### PR TITLE
Introduce PeerMessage Representation and complete readline demo

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ hkdf = "0.5.0"
 hex = "0.3"
 rand = "0.5"
 rustc-serialize = "0.3"
+regex = "1.0"
 
 
 [dev-dependencies]
@@ -21,4 +22,3 @@ ws = "0.7"
 url = "1.7"
 rustyline = "1.0"
 parking_lot = {version = "0.5", features = ["deadlock_detection"]}
-regex = "1.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate hkdf;
 extern crate rand;
+extern crate regex;
 extern crate rustc_serialize;
 extern crate serde_json;
 extern crate sha2;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,6 +38,7 @@ use util::random_bytes;
 
 pub use api::{APIAction, APIEvent, Action, IOAction, IOEvent,
               InputHelperError, TimerHandle, WSHandle};
+pub use server_messages::{deserialize_peer_message, OfferType, PeerMessage};
 
 pub struct WormholeCore {
     allocator: allocator::Allocator,

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -23,6 +23,33 @@ where
     Option::<T>::deserialize(de).or_else(|_| Ok(None))
 }
 
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PeerMessage {
+    Offer(OfferType),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OfferType {
+    Message(String),
+    File {
+        filename: String,
+        filesize: u32,
+    },
+    Directory {
+        dirname: String,
+        mode: String,
+        zipsize: u32,
+        numbytes: u32,
+        numfiles: u32,
+    },
+}
+
+pub fn deserialize_peer_message(msg: &str) -> PeerMessage {
+    serde_json::from_str(msg).unwrap()
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "type")]


### PR DESCRIPTION
I introduced PeerMessage representation which currently allows serializing and deserializing offer messages. With this now readline demo can display message received from python wormhole command. 