### PR TITLE
Clippy fixes

### DIFF
--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -11,7 +11,8 @@ use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
 
 use std::error::Error;
 use std::io;
-use std::sync::{Arc, mpsc::{channel, Sender}};
+use std::sync::{mpsc::{channel, Sender},
+                Arc};
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -33,7 +33,7 @@ impl AllocatorMachine {
             S0AIdleDisconnected => self.do_idle_disconnected(event),
             S0BIdleConnected => self.do_idle_connected(event),
             S1AAllocatingDisconnected(ref wordlist) => {
-                self.do_allocating_disconnected(event, wordlist.clone())
+                self.do_allocating_disconnected(&event, wordlist.clone())
             }
             S1BAllocatingConnected(ref wordlist) => {
                 self.do_allocating_connected(event, wordlist.clone())
@@ -77,10 +77,10 @@ impl AllocatorMachine {
 
     fn do_allocating_disconnected(
         &self,
-        event: AllocatorEvent,
+        event: &AllocatorEvent,
         wordlist: Arc<Wordlist>,
     ) -> (Option<State>, Events) {
-        match event {
+        match *event {
             Connected => (
                 Some(State::S1BAllocatingConnected(wordlist)),
                 events![RC_TxAllocate],

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -151,7 +151,7 @@ pub struct TimerHandle {
 }
 impl TimerHandle {
     pub fn new(id: u32) -> TimerHandle {
-        TimerHandle { id: id }
+        TimerHandle { id }
     }
 }
 
@@ -161,7 +161,7 @@ pub struct WSHandle {
 }
 impl WSHandle {
     pub fn new(id: u32) -> WSHandle {
-        WSHandle { id: id }
+        WSHandle { id }
     }
 }
 

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -166,9 +166,9 @@ impl BossMachine {
         let (actions, newstate) = match self.state {
             Unstarted(_) => panic!("w.start() must be called first"),
             Coding(i) => (
-                events![
-                    I_ChooseNameplate(Nameplate(nameplate.to_string()))
-                ],
+                events![I_ChooseNameplate(Nameplate(
+                    nameplate.to_string()
+                ))],
                 Coding(i),
             ),
             _ => panic!(),
@@ -343,9 +343,9 @@ mod test {
         ));
         assert_eq!(
             actions,
-            events![
-                APIAction::GotVersions(json!({"hello_app": 456})),
-            ]
+            events![APIAction::GotVersions(
+                json!({"hello_app": 456})
+            ),]
         );
     }
 

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -35,14 +35,13 @@ impl CodeMachine {
             InputtingNameplate => self.in_inputting_nameplate(event),
             InputtingWords => self.in_inputting_words(event),
             Allocating => self.in_allocating(event),
-            Known => self.in_known(event),
+            Known => self.in_known(&event),
         };
-        match newstate {
-            Some(s) => {
-                self.state = s;
-            }
-            None => {}
+
+        if let Some(s) = newstate {
+            self.state = s;
         }
+
         actions
     }
 
@@ -60,7 +59,7 @@ impl CodeMachine {
             SetCode(code) => {
                 // TODO: try!(validate_code(code))
                 let code_string = code.to_string();
-                let nc: Vec<&str> = code_string.splitn(2, "-").collect();
+                let nc: Vec<&str> = code_string.splitn(2, '-').collect();
                 let nameplate = Nameplate(nc[0].to_string());
                 (
                     Some(State::Known),
@@ -135,9 +134,9 @@ impl CodeMachine {
         }
     }
 
-    fn in_known(&mut self, event: CodeEvent) -> (Option<State>, Events) {
+    fn in_known(&mut self, event: &CodeEvent) -> (Option<State>, Events) {
         use events::CodeEvent::*;
-        match event {
+        match *event {
             AllocateCode(..) => panic!(),
             InputCode => panic!(),
             SetCode(..) => panic!(),

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -38,6 +38,7 @@ impl Deref for Key {
         &self.0
     }
 }
+
 impl fmt::Debug for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Key(REDACTED)")
@@ -54,6 +55,12 @@ impl Deref for MySide {
     }
 }
 
+impl fmt::Display for MySide {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
 // TheirSide is used for the String that arrives inside inbound messages
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TheirSide(pub String);
@@ -61,6 +68,12 @@ impl Deref for TheirSide {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
+    }
+}
+
+impl fmt::Display for TheirSide {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
     }
 }
 
@@ -101,12 +114,24 @@ impl Deref for Nameplate {
     }
 }
 
+impl fmt::Display for Nameplate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Code(pub String);
 impl Deref for Code {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
+    }
+}
+
+impl fmt::Display for Code {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
     }
 }
 
@@ -337,15 +362,15 @@ pub enum SendEvent {
 impl fmt::Debug for SendEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &SendEvent::Send(ref phase, ref plaintext) => {
+            SendEvent::Send(ref phase, ref plaintext) => {
                 write!(f, "Send({}, {})", phase, maybe_utf8(plaintext))
             }
-            &SendEvent::GotVerifiedKey(_) => write!(f, "Send(GotVerifiedKey)"),
+            SendEvent::GotVerifiedKey(_) => write!(f, "Send(GotVerifiedKey)"),
         }
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TerminatorEvent {
     Close(Mood),
     MailboxDone,

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -40,8 +40,8 @@ impl InputMachine {
 
         match event {
             Start => self.start(),
-            ChooseNameplate(nameplate) => self.choose_nameplate(nameplate),
-            ChooseWords(words) => self.choose_words(words),
+            ChooseNameplate(nameplate) => self.choose_nameplate(&nameplate),
+            ChooseWords(words) => self.choose_words(&words),
             GotNameplates(nameplates) => self.got_nameplates(nameplates),
             GotWordlist(wordlist) => self.got_wordlist(wordlist),
             RefreshNameplates => self.refresh_nameplates(),
@@ -59,7 +59,7 @@ impl InputMachine {
         }
     }
 
-    fn choose_nameplate(&mut self, nameplate: Nameplate) -> Events {
+    fn choose_nameplate(&mut self, nameplate: &Nameplate) -> Events {
         use self::State::*;
         match self.state {
             Idle => panic!("too soon"),
@@ -71,13 +71,13 @@ impl InputMachine {
         }
     }
 
-    fn choose_words(&mut self, words: String) -> Events {
+    fn choose_words(&mut self, words: &str) -> Events {
         use self::State::*;
         let mut newstate: Option<State> = None;
         let events = match self.state {
             Idle => panic!("too soon"),
             WantCode(ref nameplate) => {
-                let code = Code(format!("{}-{}", nameplate.to_string(), words));
+                let code = Code(format!("{}-{}", *nameplate, words));
                 newstate = Some(Done);
                 events![C_FinishedInput(code)]
             }
@@ -187,9 +187,9 @@ mod test {
         let actions = i.process(ChooseWords("purple-sausages".to_string()));
         assert_eq!(
             actions,
-            events![
-                C_FinishedInput(Code("4-purple-sausages".to_string()))
-            ]
+            events![C_FinishedInput(Code(
+                "4-purple-sausages".to_string()
+            ))]
         );
     }
 
@@ -314,9 +314,9 @@ mod test {
         let actions = i.process(ChooseWords("purple-sausages".to_string()));
         assert_eq!(
             actions,
-            events![
-                C_FinishedInput(Code("4-purple-sausages".to_string()))
-            ]
+            events![C_FinishedInput(Code(
+                "4-purple-sausages".to_string()
+            ))]
         );
     }
 }

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -55,26 +55,27 @@ impl KeyMachine {
 
         use self::KeyEvent::*;
         match event {
-            GotCode(ref code) => self.got_code(code.clone()),
-            GotPake(ref pake) => self.got_pake(pake.clone()),
+            GotCode(code) => self.got_code(&code),
+            GotPake(pake) => self.got_pake(pake),
         }
     }
 
-    fn got_code(&mut self, code: Code) -> Events {
+    fn got_code(&mut self, code: &Code) -> Events {
         use self::State::*;
         let oldstate = mem::replace(&mut self.state, None);
-        let events = match oldstate.unwrap() {
+        match oldstate.unwrap() {
             S0KnowNothing => {
                 let (pake_state, pake_msg_ser) = start_pake(&code, &self.appid);
                 self.state = Some(S1KnowCode(pake_state));
-                events![
-                    M_AddMessage(Phase("pake".to_string()), pake_msg_ser)
-                ]
+                events![M_AddMessage(
+                    Phase("pake".to_string()),
+                    pake_msg_ser
+                )]
             }
             S1KnowCode(_) => panic!("already got code"),
             S2KnowPake(ref their_pake_msg) => {
                 let (pake_state, pake_msg_ser) = start_pake(&code, &self.appid);
-                let key: Key = finish_pake(pake_state, their_pake_msg.clone());
+                let key: Key = finish_pake(pake_state, &their_pake_msg);
                 let versions = json!({"app_versions": {}}); // TODO: self.versions
                 let (version_phase, version_msg) =
                     build_version_msg(&self.side, &key, &versions);
@@ -88,20 +89,19 @@ impl KeyMachine {
             }
             S3KnowBoth(_) => panic!("already got code"),
             S4Scared => panic!("already scared"),
-        };
-        events
+        }
     }
 
     fn got_pake(&mut self, pake: Vec<u8>) -> Events {
         use self::State::*;
         let oldstate = mem::replace(&mut self.state, None);
-        let events = match oldstate.unwrap() {
+        match oldstate.unwrap() {
             S0KnowNothing => {
                 self.state = Some(S2KnowPake(pake));
                 events![]
             }
             S1KnowCode(pake_state) => {
-                let key: Key = finish_pake(pake_state, pake);
+                let key: Key = finish_pake(pake_state, &pake);
                 let versions = json!({"app_versions": {}}); // TODO: self.versions
                 let (version_phase, version_msg) =
                     build_version_msg(&self.side, &key, &versions);
@@ -115,8 +115,7 @@ impl KeyMachine {
             S2KnowPake(_) => panic!("already got pake"),
             S3KnowBoth(_) => panic!("already got pake"),
             S4Scared => panic!("already scared"),
-        };
-        events
+        }
     }
 }
 
@@ -133,8 +132,8 @@ fn start_pake(code: &Code, appid: &AppID) -> (SPAKE2<Ed25519Group>, Vec<u8>) {
     (pake_state, pake_msg_ser)
 }
 
-fn finish_pake(pake_state: SPAKE2<Ed25519Group>, peer_msg: Vec<u8>) -> Key {
-    let msg2 = extract_pake_msg(peer_msg).unwrap();
+fn finish_pake(pake_state: SPAKE2<Ed25519Group>, peer_msg: &[u8]) -> Key {
+    let msg2 = extract_pake_msg(&peer_msg).unwrap();
     Key(pake_state
         .finish(&hex::decode(msg2).unwrap())
         .unwrap())
@@ -148,19 +147,17 @@ fn build_version_msg(
     let phase = "version";
     let data_key = derive_phase_key(&side.to_string(), &key, &phase);
     let plaintext = versions.to_string();
-    let (_nonce, encrypted) = encrypt_data(data_key, &plaintext.as_bytes());
+    let (_nonce, encrypted) = encrypt_data(&data_key, &plaintext.as_bytes());
     (Phase(phase.to_string()), encrypted)
 }
 
-fn extract_pake_msg(body: Vec<u8>) -> Option<String> {
-    let pake_msg = serde_json::from_slice(&body)
+fn extract_pake_msg(body: &[u8]) -> Option<String> {
+    serde_json::from_slice(&body)
         .and_then(|res: PhaseMessage| Ok(res.pake_v1))
-        .ok();
-
-    pake_msg
+        .ok()
 }
 
-pub fn encrypt_data(key: Vec<u8>, plaintext: &[u8]) -> (Vec<u8>, Vec<u8>) {
+pub fn encrypt_data(key: &[u8], plaintext: &[u8]) -> (Vec<u8>, Vec<u8>) {
     let nonce = secretbox::gen_nonce();
     let sodium_key = secretbox::Key::from_slice(&key).unwrap();
     let ciphertext = secretbox::seal(&plaintext, &nonce, &sodium_key);
@@ -172,7 +169,7 @@ pub fn encrypt_data(key: Vec<u8>, plaintext: &[u8]) -> (Vec<u8>, Vec<u8>) {
 
 // TODO: return an Result with a proper error type
 // secretbox::open() returns Result<Vec<u8>, ()> which is not helpful.
-pub fn decrypt_data(key: Vec<u8>, encrypted: &[u8]) -> Option<Vec<u8>> {
+pub fn decrypt_data(key: &[u8], encrypted: &[u8]) -> Option<Vec<u8>> {
     let (nonce, ciphertext) =
         encrypted.split_at(sodiumoxide::crypto::secretbox::NONCEBYTES);
     assert_eq!(
@@ -200,19 +197,9 @@ pub fn derive_key(key: &[u8], purpose: &[u8], length: usize) -> Vec<u8> {
 pub fn derive_phase_key(side: &str, key: &Key, phase: &str) -> Vec<u8> {
     let side_bytes = side.as_bytes();
     let phase_bytes = phase.as_bytes();
-    let side_digest: Vec<u8> = sha256_digest(side_bytes)
-        .iter()
-        .cloned()
-        .collect();
-    let phase_digest: Vec<u8> = sha256_digest(phase_bytes)
-        .iter()
-        .cloned()
-        .collect();
-    let mut purpose_vec: Vec<u8> = "wormhole:phase:"
-        .as_bytes()
-        .iter()
-        .cloned()
-        .collect();
+    let side_digest: Vec<u8> = sha256_digest(side_bytes);
+    let phase_digest: Vec<u8> = sha256_digest(phase_bytes);
+    let mut purpose_vec: Vec<u8> = b"wormhole:phase:".to_vec();
     purpose_vec.extend(side_digest);
     purpose_vec.extend(phase_digest);
 

--- a/core/src/lister.rs
+++ b/core/src/lister.rs
@@ -36,7 +36,7 @@ impl ListerMachine {
     pub fn process(&mut self, event: ListerEvent) -> Events {
         use self::State::*;
         let (newstate, actions) = match self.state {
-            S0A => self.do_s0a(event),
+            S0A => self.do_s0a(&event),
             S0B => self.do_s0b(event),
             S1A => self.do_s1a(event),
             S1B => self.do_s1b(event),
@@ -46,8 +46,8 @@ impl ListerMachine {
         actions
     }
 
-    fn do_s0a(&self, event: ListerEvent) -> (State, Events) {
-        match event {
+    fn do_s0a(&self, event: &ListerEvent) -> (State, Events) {
+        match *event {
             Connected => (State::S0B, events![]),
             Refresh => (State::S1A, events![]),
             _ => (State::S0A, events![]),

--- a/core/src/nameplate.rs
+++ b/core/src/nameplate.rs
@@ -56,11 +56,8 @@ impl NameplateMachine {
             S4B(ref nameplate) => self.do_s4b(&nameplate, event),
             S5 => self.do_s5(event),
         };
-        match newstate {
-            Some(s) => {
-                self.state = s;
-            }
-            None => {}
+        if let Some(s) = newstate {
+            self.state = s;
         }
         actions
     }

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -69,10 +69,10 @@ impl RendezvousMachine {
             appid: appid.clone(),
             relay_url: relay_url.to_string(),
             side: side.clone(),
-            retry_timer: retry_timer,
+            retry_timer,
             state: State::Idle,
             connected_at_least_once: false,
-            wsh: wsh,
+            wsh,
             reconnect_timer: None,
         }
     }
@@ -94,15 +94,15 @@ impl RendezvousMachine {
         println!("rendezvous: {:?}", e);
         match e {
             Start => self.start(),
-            TxBind(appid, side) => self.send(bind(&appid, &side)),
-            TxOpen(mailbox) => self.send(open(&mailbox)),
-            TxAdd(phase, body) => self.send(add(&phase, &body)),
-            TxClose(mailbox, mood) => self.send(close(&mailbox, mood)),
+            TxBind(appid, side) => self.send(&bind(&appid, &side)),
+            TxOpen(mailbox) => self.send(&open(&mailbox)),
+            TxAdd(phase, body) => self.send(&add(&phase, &body)),
+            TxClose(mailbox, mood) => self.send(&close(&mailbox, mood)),
             Stop => self.stop(),
-            TxClaim(nameplate) => self.send(claim(&nameplate)),
-            TxRelease(nameplate) => self.send(release(&nameplate)),
-            TxAllocate => self.send(allocate()),
-            TxList => self.send(list()),
+            TxClaim(nameplate) => self.send(&claim(&nameplate)),
+            TxRelease(nameplate) => self.send(&release(&nameplate)),
+            TxAllocate => self.send(&allocate()),
+            TxList => self.send(&list()),
         }
     }
 
@@ -113,9 +113,10 @@ impl RendezvousMachine {
         let actions;
         let newstate = match self.state {
             State::Idle => {
-                actions = events![
-                    IOAction::WebSocketOpen(self.wsh, self.relay_url.clone())
-                ];
+                actions = events![IOAction::WebSocketOpen(
+                    self.wsh,
+                    self.relay_url.clone()
+                )];
                 //"url".to_string());
                 State::Connecting
             }
@@ -163,13 +164,11 @@ impl RendezvousMachine {
                 phase,
                 body,
                 //id,
-            } => events![
-                M_RxMessage(
-                    TheirSide(side),
-                    Phase(phase),
-                    hex::decode(body).unwrap()
-                )
-            ],
+            } => events![M_RxMessage(
+                TheirSide(side),
+                Phase(phase),
+                hex::decode(body).unwrap()
+            )],
             Allocated { nameplate } => {
                 events![A_RxAllocated(Nameplate(nameplate))]
             }
@@ -190,9 +189,10 @@ impl RendezvousMachine {
                 let new_handle = TimerHandle::new(2);
                 self.reconnect_timer = Some(new_handle);
                 (
-                    events![
-                        IOAction::StartTimer(new_handle, self.retry_timer)
-                    ],
+                    events![IOAction::StartTimer(
+                        new_handle,
+                        self.retry_timer
+                    )],
                     State::Waiting,
                 )
             }
@@ -250,12 +250,12 @@ impl RendezvousMachine {
         actions
     }
 
-    fn send(&mut self, m: OutboundMessage) -> Events {
+    fn send(&mut self, m: &OutboundMessage) -> Events {
         // TODO: add 'id' (a random string, used to correlate 'ack' responses
         // for timing-graph instrumentation)
         let s = IOAction::WebSocketSendMessage(
             self.wsh,
-            serde_json::to_string(&m).unwrap(),
+            serde_json::to_string(m).unwrap(),
         );
         events![s]
     }

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -140,7 +140,7 @@ pub fn deserialize_outbound(s: &str) -> OutboundMessage {
 
 #[allow(dead_code)]
 pub fn ping(ping: u32) -> OutboundMessage {
-    OutboundMessage::Ping { ping: ping }
+    OutboundMessage::Ping { ping }
 }
 
 // Server sends only these

--- a/core/src/terminator.rs
+++ b/core/src/terminator.rs
@@ -67,7 +67,7 @@ impl TerminatorMachine {
         match event {
             NameplateDone => (State::S0o, events![]),
             Close(mood) => (State::Sn, events![N_Close, M_Close(mood)]),
-            _ => panic!("Got {:?} too early, Nameplate still active"),
+            _ => panic!("Got too early, Nameplate still active"),
         }
     }
 
@@ -75,7 +75,7 @@ impl TerminatorMachine {
         match event {
             MailboxDone => (State::S0o, events![]),
             Close(mood) => (State::Sm, events![N_Close, M_Close(mood)]),
-            _ => panic!("Got {:?} too early, Mailbox still active"),
+            _ => panic!("Got too early, Mailbox still active"),
         }
     }
 

--- a/core/src/wordlist.rs
+++ b/core/src/wordlist.rs
@@ -22,8 +22,8 @@ impl Wordlist {
     #[cfg(test)]
     pub fn new(num_words: usize, words: Vec<Vec<String>>) -> Wordlist {
         Wordlist {
-            num_words: num_words,
-            words: words,
+            num_words,
+            words,
         }
     }
 
@@ -105,7 +105,7 @@ fn load_pgpwords() -> Vec<Vec<String>> {
 
 pub fn default_wordlist(num_words: usize) -> Wordlist {
     Wordlist {
-        num_words: num_words,
+        num_words,
         words: load_pgpwords(),
     }
 }


### PR DESCRIPTION
All most all clippy warnings are handled except one triggered on use of `events![]`. This happens because when we do empty events![] it leads to below expanded code

```rust
let tmpvec = Events::new();
tmpvec
```

I tried to silence it by inserting  `#[cfg_attr(feature = "cargo-clippy"), allow(let_and_return)]` but that did not work, to silence it I guess I need to add the above line every where we use `events![]`, which I felt was over kill. So for now I've kept that open.