### PR TITLE
Peer messages moved to transfer module and examples adapted

### DIFF
--- a/core/examples/ws.rs
+++ b/core/examples/ws.rs
@@ -1,8 +1,8 @@
 extern crate magic_wormhole_core;
 extern crate url;
 extern crate ws;
-use magic_wormhole_core::{APIAction, APIEvent, Action, AnswerType, IOAction,
-                          IOEvent, OfferType, PeerMessage, WSHandle,
+use magic_wormhole_core::{message, APIAction, APIEvent, Action, AnswerType,
+                          IOAction, IOEvent, PeerMessage, WSHandle,
                           WormholeCore};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -77,9 +77,7 @@ impl ws::Handler for MyHandler {
         // TODO: this should go just after .start()
         let actions = wc.do_api(APIEvent::AllocateCode(2));
         process_actions(&self.out, actions);
-        let offer = PeerMessage::Offer(OfferType::Message(
-            "hello from rust!".to_string(),
-        )).serialize();
+        let offer = message("hello from rust!").serialize();
         // let offer = json!({"offer": {"message": "hello from rust"}});
         // then expect {"answer": {"message_ack": "ok"}}
         let actions = wc.do_api(APIEvent::Send(offer.to_string().into_bytes()));

--- a/core/examples/ws.rs
+++ b/core/examples/ws.rs
@@ -151,6 +151,9 @@ fn process_actions(out: &ws::Sender, actions: Vec<Action>) {
                                 }
                             }
                         },
+                        PeerMessage::Transit(..) => {
+                            println!("transit message recieved")
+                        }
                     }
                 }
                 _ => println!("action {:?}", api),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ mod server_messages;
 mod terminator;
 #[cfg(test)]
 mod test;
+mod transfer;
 mod util;
 mod wordlist;
 
@@ -43,7 +44,9 @@ use util::random_bytes;
 
 pub use api::{APIAction, APIEvent, Action, IOAction, IOEvent,
               InputHelperError, Mood, TimerHandle, WSHandle};
-pub use server_messages::{AnswerType, OfferType, PeerMessage};
+pub use transfer::{error_message, file_ack, message, message_ack,
+                   offer_directory, offer_file, AnswerType, OfferType,
+                   PeerMessage};
 
 pub struct WormholeCore {
     allocator: allocator::AllocatorMachine,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,9 +45,10 @@ use util::random_bytes;
 
 pub use api::{APIAction, APIEvent, Action, IOAction, IOEvent,
               InputHelperError, Mood, TimerHandle, WSHandle};
-pub use transfer::{error_message, file_ack, message, message_ack,
-                   offer_directory, offer_file, AnswerType, OfferType,
-                   PeerMessage};
+pub use transfer::{direct_type, error_message, file_ack, message, message_ack,
+                   offer_directory, offer_file, relay_type, transit,
+                   Abilities, AnswerType, DirectType, Hints, OfferType,
+                   PeerMessage, RelayType, TransitType};
 
 pub struct WormholeCore {
     allocator: allocator::AllocatorMachine,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/core/src/server_messages.rs
+++ b/core/src/server_messages.rs
@@ -9,50 +9,6 @@ pub struct Nameplate {
     pub id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum PeerMessage {
-    Offer(OfferType),
-    Answer(AnswerType),
-    Error(String),
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum OfferType {
-    Message(String),
-    File {
-        filename: String,
-        filesize: u32,
-    },
-    Directory {
-        dirname: String,
-        mode: String,
-        zipsize: u32,
-        numbytes: u32,
-        numfiles: u32,
-    },
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum AnswerType {
-    MessageAck(String),
-    FileAck(String),
-}
-
-impl PeerMessage {
-    pub fn serialize(&self) -> String {
-        json!(self).to_string()
-    }
-
-    // TODO: This can error out so we should actually have error returning
-    // capability here
-    pub fn deserialize(msg: &str) -> Self {
-        serde_json::from_str(msg).unwrap()
-    }
-}
-
 // Client sends only these
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/core/src/transfer.rs
+++ b/core/src/transfer.rs
@@ -1,0 +1,134 @@
+use serde_json;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PeerMessage {
+    Offer(OfferType),
+    Answer(AnswerType),
+    Error(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OfferType {
+    Message(String),
+    File {
+        filename: String,
+        filesize: u32,
+    },
+    Directory {
+        dirname: String,
+        mode: String,
+        zipsize: u32,
+        numbytes: u32,
+        numfiles: u32,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerType {
+    MessageAck(String),
+    FileAck(String),
+}
+
+impl PeerMessage {
+    pub fn serialize(&self) -> String {
+        json!(self).to_string()
+    }
+
+    // TODO: This can error out so we should actually have error returning
+    // capability here
+    pub fn deserialize(msg: &str) -> Self {
+        serde_json::from_str(msg).unwrap()
+    }
+}
+
+pub fn message(msg: &str) -> PeerMessage {
+    PeerMessage::Offer(OfferType::Message(msg.to_string()))
+}
+
+pub fn offer_file(name: &str, size: u32) -> PeerMessage {
+    PeerMessage::Offer(OfferType::File {
+        filename: name.to_string(),
+        filesize: size,
+    })
+}
+
+pub fn message_ack(msg: &str) -> PeerMessage {
+    PeerMessage::Answer(AnswerType::MessageAck(msg.to_string()))
+}
+
+pub fn file_ack(msg: &str) -> PeerMessage {
+    PeerMessage::Answer(AnswerType::FileAck(msg.to_string()))
+}
+
+pub fn error_message(msg: &str) -> PeerMessage {
+    PeerMessage::Error(msg.to_string())
+}
+
+pub fn offer_directory(
+    name: &str,
+    mode: &str,
+    compressed_size: u32,
+    numbytes: u32,
+    numfiles: u32,
+) -> PeerMessage {
+    PeerMessage::Offer(OfferType::Directory {
+        dirname: name.to_string(),
+        mode: mode.to_string(),
+        zipsize: compressed_size,
+        numbytes,
+        numfiles,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_message() {
+        let m1 = message("hello from rust");
+        assert_eq!(
+            m1.serialize(),
+            "{\"offer\":{\"message\":\"hello from rust\"}}"
+        );
+    }
+
+    #[test]
+    fn test_offer_file() {
+        let f1 = offer_file("somefile.txt", 34556);
+        assert_eq!(
+            f1.serialize(),
+            "{\"offer\":{\"file\":{\"filename\":\"somefile.txt\",\"filesize\":34556}}}"
+       );
+    }
+
+    #[test]
+    fn test_offer_directory() {
+        let d1 = offer_directory("somedirectory", "zipped", 45, 1234, 10);
+        assert_eq!(
+            d1.serialize(),
+            "{\"offer\":{\"directory\":{\"dirname\":\"somedirectory\",\"mode\":\"zipped\",\"numbytes\":1234,\"numfiles\":10,\"zipsize\":45}}}"
+        );
+    }
+
+    #[test]
+    fn test_message_ack() {
+        let m1 = message_ack("ok");
+        assert_eq!(
+            m1.serialize(),
+            "{\"answer\":{\"message_ack\":\"ok\"}}"
+        );
+    }
+
+    #[test]
+    fn test_file_ack() {
+        let f1 = file_ack("ok");
+        assert_eq!(
+            f1.serialize(),
+            "{\"answer\":{\"file_ack\":\"ok\"}}"
+        );
+    }
+}

--- a/io/blocking/examples/receive.rs
+++ b/io/blocking/examples/receive.rs
@@ -32,6 +32,7 @@ fn main() {
             }
             OfferType::Directory { .. } => {
                 println!("Received directory offer: {:?}", offer);
+                // TODO: We are doing file_ack without asking user
                 w.send_message(file_ack("ok").serialize().as_bytes());
             }
         },
@@ -39,6 +40,10 @@ fn main() {
             panic!("Should not receive answer type, I'm receiver")
         }
         PeerMessage::Error(err) => println!("Something went wrong: {}", err),
+        PeerMessage::Transit(transit) => {
+            // TODO: This should start transit server connection or direct file transfer
+            println!("Transit Message received: {:?}", transit)
+        }
     };
     println!("closing..");
     w.close();

--- a/io/blocking/examples/receive.rs
+++ b/io/blocking/examples/receive.rs
@@ -1,6 +1,10 @@
 extern crate hex;
+extern crate magic_wormhole_core;
 extern crate magic_wormhole_io_blocking;
+
+use magic_wormhole_core::{file_ack, message_ack, OfferType, PeerMessage};
 use magic_wormhole_io_blocking::Wormhole;
+use std::str;
 
 // Can ws do hostname lookup? Use ip addr, not localhost, for now
 const MAILBOX_SERVER: &'static str = "ws://127.0.0.1:4000/v1";
@@ -14,11 +18,28 @@ fn main() {
     println!("verifier: {}", hex::encode(verifier));
     println!("receiving..");
     let msg = w.get_message();
-    use std::str;
-    println!(
-        "message received: {}",
-        str::from_utf8(&msg).unwrap()
-    );
+    let actual_message =
+        PeerMessage::deserialize(str::from_utf8(&msg).unwrap());
+    match actual_message {
+        PeerMessage::Offer(offer) => match offer {
+            OfferType::Message(msg) => {
+                println!("{}", msg);
+                w.send_message(message_ack("ok").serialize().as_bytes());
+            }
+            OfferType::File { .. } => {
+                println!("Received file offer {:?}", offer);
+                w.send_message(file_ack("ok").serialize().as_bytes());
+            }
+            OfferType::Directory { .. } => {
+                println!("Received directory offer: {:?}", offer);
+                w.send_message(file_ack("ok").serialize().as_bytes());
+            }
+        },
+        PeerMessage::Answer(_) => {
+            panic!("Should not receive answer type, I'm receiver")
+        }
+        PeerMessage::Error(err) => println!("Something went wrong: {}", err),
+    };
     println!("closing..");
     w.close();
     println!("closed");

--- a/io/blocking/examples/send.rs
+++ b/io/blocking/examples/send.rs
@@ -1,5 +1,8 @@
 extern crate hex;
+extern crate magic_wormhole_core;
 extern crate magic_wormhole_io_blocking;
+
+use magic_wormhole_core::message;
 use magic_wormhole_io_blocking::Wormhole;
 
 // Can ws do hostname lookup? Use ip addr, not localhost, for now
@@ -9,12 +12,16 @@ const APPID: &'static str = "lothar.com/wormhole/text-or-file-xfer";
 fn main() {
     let mut w = Wormhole::new(APPID, MAILBOX_SERVER);
     println!("connecting..");
-    w.set_code("4-purple-sausages");
-    //w.allocate_code(2);
+    // w.set_code("4-purple-sausages");
+    w.allocate_code(2);
     let code = w.get_code();
     println!("code is: {}", code);
     println!("sending..");
-    w.send_message(b"hello");
+    w.send_message(
+        message("hello from rust!")
+            .serialize()
+            .as_bytes(),
+    );
     println!("sent..");
     // if we close right away, we won't actually send anything. Wait for at
     // least the verifier to be printed, that ought to give our outbound


### PR DESCRIPTION
As discussed earlier on IRC, I've moved all the peer messages into transfer module. I've created some new methods to help creating message types like one we have in server_messages module. Examples are now adapted and successfully receives or sends message from python counterpart.

Some pending parts are adding support for transit messages which I'm currently working on. This should be merged after #51 as its based on that branch.