### PR TITLE
travis: use rustfmt from 1.26.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
 
 matrix:
   include:
-    - rust: 1.26.0 # lock down for consistent rustfmt behavior
+    - rust: 1.26.1 # lock down for consistent rustfmt behavior
       env: RUSTFMT
       install:
         - rustup component add rustfmt-preview

--- a/core/examples/readline.rs
+++ b/core/examples/readline.rs
@@ -11,7 +11,8 @@ use magic_wormhole_core::{APIAction, APIEvent, Action, IOAction, IOEvent,
 
 use std::error::Error;
 use std::io;
-use std::sync::{Arc, mpsc::{channel, Sender}};
+use std::sync::{mpsc::{channel, Sender},
+                Arc};
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -166,9 +166,9 @@ impl BossMachine {
         let (actions, newstate) = match self.state {
             Unstarted(_) => panic!("w.start() must be called first"),
             Coding(i) => (
-                events![
-                    I_ChooseNameplate(Nameplate(nameplate.to_string()))
-                ],
+                events![I_ChooseNameplate(Nameplate(
+                    nameplate.to_string()
+                ))],
                 Coding(i),
             ),
             _ => panic!(),
@@ -343,9 +343,9 @@ mod test {
         ));
         assert_eq!(
             actions,
-            events![
-                APIAction::GotVersions(json!({"hello_app": 456})),
-            ]
+            events![APIAction::GotVersions(
+                json!({"hello_app": 456})
+            ),]
         );
     }
 

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -187,9 +187,9 @@ mod test {
         let actions = i.process(ChooseWords("purple-sausages".to_string()));
         assert_eq!(
             actions,
-            events![
-                C_FinishedInput(Code("4-purple-sausages".to_string()))
-            ]
+            events![C_FinishedInput(Code(
+                "4-purple-sausages".to_string()
+            ))]
         );
     }
 
@@ -314,9 +314,9 @@ mod test {
         let actions = i.process(ChooseWords("purple-sausages".to_string()));
         assert_eq!(
             actions,
-            events![
-                C_FinishedInput(Code("4-purple-sausages".to_string()))
-            ]
+            events![C_FinishedInput(Code(
+                "4-purple-sausages".to_string()
+            ))]
         );
     }
 }

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -67,9 +67,10 @@ impl KeyMachine {
             S0KnowNothing => {
                 let (pake_state, pake_msg_ser) = start_pake(&code, &self.appid);
                 self.state = Some(S1KnowCode(pake_state));
-                events![
-                    M_AddMessage(Phase("pake".to_string()), pake_msg_ser)
-                ]
+                events![M_AddMessage(
+                    Phase("pake".to_string()),
+                    pake_msg_ser
+                )]
             }
             S1KnowCode(_) => panic!("already got code"),
             S2KnowPake(ref their_pake_msg) => {

--- a/core/src/rendezvous.rs
+++ b/core/src/rendezvous.rs
@@ -113,9 +113,10 @@ impl RendezvousMachine {
         let actions;
         let newstate = match self.state {
             State::Idle => {
-                actions = events![
-                    IOAction::WebSocketOpen(self.wsh, self.relay_url.clone())
-                ];
+                actions = events![IOAction::WebSocketOpen(
+                    self.wsh,
+                    self.relay_url.clone()
+                )];
                 //"url".to_string());
                 State::Connecting
             }
@@ -163,13 +164,11 @@ impl RendezvousMachine {
                 phase,
                 body,
                 //id,
-            } => events![
-                M_RxMessage(
-                    TheirSide(side),
-                    Phase(phase),
-                    hex::decode(body).unwrap()
-                )
-            ],
+            } => events![M_RxMessage(
+                TheirSide(side),
+                Phase(phase),
+                hex::decode(body).unwrap()
+            )],
             Allocated { nameplate } => {
                 events![A_RxAllocated(Nameplate(nameplate))]
             }
@@ -190,9 +189,10 @@ impl RendezvousMachine {
                 let new_handle = TimerHandle::new(2);
                 self.reconnect_timer = Some(new_handle);
                 (
-                    events![
-                        IOAction::StartTimer(new_handle, self.retry_timer)
-                    ],
+                    events![IOAction::StartTimer(
+                        new_handle,
+                        self.retry_timer
+                    )],
                     State::Waiting,
                 )
             }


### PR DESCRIPTION
Let's see if this gets us rustfmt-0.4.2, in which case we'll add a second commit to reformat things to match. My guess is that the newer rustfmt knows how to wrap some lines that it didn't before.
