### PR TITLE
fix clippy-0.0.211 complaints

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -97,9 +97,9 @@ pub enum Mood {
 }
 
 impl Mood {
-    fn to_string(&self) -> String {
+    fn to_protocol_string(self) -> String {
         // this is used for protocol messages as well as debug output
-        match *self {
+        match self {
             Mood::Happy => "happy".to_string(),
             Mood::Lonely => "lonely".to_string(),
             Mood::Error => "errory".to_string(),
@@ -111,7 +111,7 @@ impl Mood {
 
 impl fmt::Display for Mood {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self.to_protocol_string())
     }
 }
 

--- a/core/src/boss.rs
+++ b/core/src/boss.rs
@@ -38,9 +38,9 @@ pub struct BossMachine {
 }
 
 impl State {
-    pub fn increment_phase(&self) -> Self {
+    pub fn increment_phase(self) -> Self {
         use self::State::*;
-        match *self {
+        match self {
             Unstarted(i) => Unstarted(i + 1),
             Empty(i) => Empty(i + 1),
             Coding(i) => Coding(i + 1),


### PR DESCRIPTION
Changing Mood::to_string to take 'self' instead of '&self' then makes clippy
think that Mood::to_string is unused (probably because we implement Display
for Mood, delegating to that to_string). Removing Mood::to_string causes an
unterminated recursion in test_close_errory when the Display's to_string
calls itself instead of calling Mood::to_string. I renamed it to
Mood::to_protocol_string to fix it.