### PR TITLE
deps: bump to sodiumoxide-0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,6 @@ matrix:
   allow_failures:
     - rust: nightly # both compiles and clippy
 
-
-# copied from https://github.com/dnaq/sodiumoxide/blob/master/.travis.yml
-before_install:
-  - wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz
-  - tar xvfz libsodium-1.0.16.tar.gz
-  - cd libsodium-1.0.16 && ./configure --prefix=$HOME/installed_libsodium && make && make install && cd ..
-  - export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
-  - export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
-
 script:
   - cargo clean
   - cargo build --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ travis-ci = { repository = "warner/magic-wormhole.rs" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-sodiumoxide = "0.0.16"
+sodiumoxide = "0.2"
 spake2 = "0.1.0"
 sha2 = "0.8"
 hkdf = "0.7.0"


### PR DESCRIPTION
this should be a lot easier to build, as it automatically (safely) downloads
the libsodium tarball instead of relying upon having something installed on
the host