### PR TITLE
Avoid stringly-typed APIs in several spots

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
 
-use hex;
-
 #[macro_use]
 mod events;
 mod allocator;
@@ -28,7 +26,6 @@ mod wordlist;
 
 pub use self::events::{AppID, Code};
 use self::events::{Event, Events, MySide, Nameplate};
-use self::util::random_bytes;
 use log::trace;
 
 pub use self::api::{
@@ -63,19 +60,13 @@ pub struct WormholeCore {
     from.into_iter().map(|r| Result::from(r)).collect::<Vec<Result>>()
 }*/
 
-fn generate_side() -> String {
-    let mut bytes: [u8; 5] = [0; 5];
-    random_bytes(&mut bytes);
-    hex::encode(bytes)
-}
-
 impl WormholeCore {
     pub fn new<T>(appid: T, relay_url: &str) -> WormholeCore
     where
         T: Into<AppID>,
     {
         let appid: AppID = appid.into();
-        let side = MySide(generate_side());
+        let side = MySide::generate();
         WormholeCore {
             allocator: allocator::AllocatorMachine::new(),
             boss: boss::BossMachine::new(),

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -1,6 +1,7 @@
 use super::events::{Code, Key};
 use super::util::maybe_utf8;
 use hex;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::error::Error;
 use std::fmt;
@@ -87,32 +88,18 @@ impl Error for InputHelperError {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Deserialize, Serialize)]
 pub enum Mood {
+    #[serde(rename = "happy")]
     Happy,
+    #[serde(rename = "lonely")]
     Lonely,
+    #[serde(rename = "errory")]
     Errory,
+    #[serde(rename = "scary")]
     Scared,
+    #[serde(rename = "unwelcome")]
     Unwelcome,
-}
-
-impl Mood {
-    fn to_protocol_string(self) -> String {
-        // this is used for protocol messages as well as debug output
-        match self {
-            Mood::Happy => String::from("happy"),
-            Mood::Lonely => String::from("lonely"),
-            Mood::Errory => String::from("errory"),
-            Mood::Scared => String::from("scary"),
-            Mood::Unwelcome => String::from("unwelcome"),
-        }
-    }
-}
-
-impl fmt::Display for Mood {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_protocol_string())
-    }
 }
 
 #[derive(PartialEq)]

--- a/src/core/boss.rs
+++ b/src/core/boss.rs
@@ -2,10 +2,8 @@ use super::api::Mood;
 use super::events::{Events, Nameplate, Phase};
 use super::wordlist::default_wordlist;
 use serde_json::json;
-use std::str::FromStr;
 use std::sync::Arc;
 
-use regex::Regex;
 use serde_json;
 
 // we process these
@@ -244,8 +242,7 @@ impl BossMachine {
                     old_state
                 }
                 GotMessage(phase, plaintext) => {
-                    let phase_pattern = Regex::from_str("\\d+").unwrap();
-                    if phase.to_string() == "version" {
+                    if phase.is_version() {
                         // TODO handle error conditions
                         use serde_json::Value;
                         let version_str = String::from_utf8(plaintext).unwrap();
@@ -256,7 +253,7 @@ impl BossMachine {
                             None => json!({}),
                         };
                         actions.push(APIAction::GotVersions(app_versions));
-                    } else if phase_pattern.is_match(&phase) {
+                    } else if phase.to_num().is_some() {
                         actions.push(APIAction::GotMessage(plaintext));
                     } else {
                         // TODO: log and ignore, for future expansion

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -110,19 +110,9 @@ impl fmt::Display for Phase {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
 pub struct Mailbox(pub String);
-impl Deref for Mailbox {
-    type Target = String;
-    fn deref(&self) -> &String {
-        &self.0
-    }
-}
-impl fmt::Display for Mailbox {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Mailbox({})", &self.0)
-    }
-}
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Nameplate(pub String);
@@ -275,7 +265,7 @@ impl fmt::Debug for MailboxEvent {
             ),
             RxClosed => String::from("RxClosed"),
             Close(ref mood) => format!("Close({:?})", mood),
-            GotMailbox(ref mailbox) => format!("GotMailbox({})", mailbox),
+            GotMailbox(ref mailbox) => format!("GotMailbox({:?})", mailbox),
             AddMessage(ref phase, ref body) => {
                 format!("AddMessage({}, {})", phase, maybe_utf8(body))
             }
@@ -359,12 +349,12 @@ impl fmt::Debug for RendezvousEvent {
             TxBind(ref appid, ref side) => {
                 format!("TxBind(appid={:?}, side={:?})", appid, side)
             }
-            TxOpen(ref mailbox) => format!("TxOpen({})", mailbox),
+            TxOpen(ref mailbox) => format!("TxOpen({:?})", mailbox),
             TxAdd(ref phase, ref body) => {
                 format!("TxAdd({}, {})", phase, maybe_utf8(body))
             }
             TxClose(ref mailbox, ref mood) => {
-                format!("TxClose({}, {:?})", mailbox, mood)
+                format!("TxClose({:?}, {:?})", mailbox, mood)
             }
             Stop => String::from("Stop"),
             TxClaim(ref nameplate) => format!("TxClaim({:?})", nameplate),

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -1,4 +1,5 @@
 use hex;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;
 use std::iter::FromIterator;
@@ -11,19 +12,9 @@ use super::util::maybe_utf8;
 
 pub use super::wordlist::Wordlist;
 
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
 pub struct AppID(pub String);
-impl Deref for AppID {
-    type Target = String;
-    fn deref(&self) -> &String {
-        &self.0
-    }
-}
-impl fmt::Display for AppID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.0)
-    }
-}
 
 impl<'a> From<&'a str> for AppID {
     fn from(s: &'a str) -> AppID {
@@ -339,7 +330,7 @@ impl fmt::Debug for RendezvousEvent {
         let t = match *self {
             Start => String::from("Start"),
             TxBind(ref appid, ref side) => {
-                format!("TxBind(appid={}, side={:?})", appid, side)
+                format!("TxBind(appid={:?}, side={:?})", appid, side)
             }
             TxOpen(ref mailbox) => format!("TxOpen({})", mailbox),
             TxAdd(ref phase, ref body) => {

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -58,7 +58,7 @@ impl KeyMachine {
         t1.detail("waiting", "crypto");
         let (pake_state, msg1) = SPAKE2::<Ed25519Group>::start_symmetric(
             &Password::new(code.as_bytes()),
-            &Identity::new(self.appid.as_bytes()),
+            &Identity::new(self.appid.0.as_bytes()),
         );
         let payload = util::bytes_to_hexstr(&msg1);
         let pake_msg = PhaseMessage { pake_v1: payload };

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -145,7 +145,7 @@ fn build_version_msg(
     let data_key = derive_phase_key(&side, &key, &phase);
     let plaintext = versions.to_string();
     let (_nonce, encrypted) = encrypt_data(&data_key, &plaintext.as_bytes());
-    (Phase(phase.to_string()), encrypted)
+    (phase, encrypted)
 }
 
 fn extract_pake_msg(body: &[u8]) -> Option<String> {
@@ -208,7 +208,7 @@ pub fn derive_phase_key(
     phase: &Phase,
 ) -> Vec<u8> {
     let side_bytes = side.0.as_bytes();
-    let phase_bytes = phase.as_bytes();
+    let phase_bytes = phase.0.as_bytes();
     let side_digest: Vec<u8> = sha256_digest(side_bytes);
     let phase_digest: Vec<u8> = sha256_digest(phase_bytes);
     let mut purpose_vec: Vec<u8> = b"wormhole:phase:".to_vec();

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -13,7 +13,7 @@ use xsalsa20poly1305::{
     XSalsa20Poly1305,
 };
 
-use super::events::{AppID, Code, Events, Key, MySide, Phase};
+use super::events::{AppID, Code, EitherSide, Events, Key, MySide, Phase};
 use super::util;
 // we process these
 use super::events::KeyEvent;
@@ -142,7 +142,7 @@ fn build_version_msg(
     versions: &Value,
 ) -> (Phase, Vec<u8>) {
     let phase = Phase(String::from("version"));
-    let data_key = derive_phase_key(&side.to_string(), &key, &phase);
+    let data_key = derive_phase_key(&side, &key, &phase);
     let plaintext = versions.to_string();
     let (_nonce, encrypted) = encrypt_data(&data_key, &plaintext.as_bytes());
     (Phase(phase.to_string()), encrypted)
@@ -202,8 +202,12 @@ pub fn derive_key(key: &[u8], purpose: &[u8], length: usize) -> Vec<u8> {
     v
 }
 
-pub fn derive_phase_key(side: &str, key: &Key, phase: &Phase) -> Vec<u8> {
-    let side_bytes = side.as_bytes();
+pub fn derive_phase_key(
+    side: &EitherSide,
+    key: &Key,
+    phase: &Phase,
+) -> Vec<u8> {
+    let side_bytes = side.0.as_bytes();
     let phase_bytes = phase.as_bytes();
     let side_digest: Vec<u8> = sha256_digest(side_bytes);
     let phase_digest: Vec<u8> = sha256_digest(phase_bytes);
@@ -224,14 +228,14 @@ pub fn derive_verifier(key: &Key) -> Vec<u8> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::core::events::{AppID, MySide};
+    use crate::core::events::{AppID, EitherSide};
     use hex;
 
     #[test]
     fn test_extract_pake_msg() {
         let _key = super::KeyMachine::new(
             &AppID(String::from("appid")),
-            &MySide(String::from("side1")),
+            &MySide::unchecked_from_string(String::from("side1")),
         );
 
         let s1 = "7b2270616b655f7631223a22353337363331646366643064336164386130346234663531643935336131343563386538626663373830646461393834373934656634666136656536306339663665227d";
@@ -261,26 +265,38 @@ mod test {
             "588ba9eef353778b074413a0140205d90d7479e36e0dd4ee35bb729d26131ef1",
         )
         .unwrap());
-        let dk11 =
-            derive_phase_key("side1", &main, &Phase(String::from("phase1")));
+        let dk11 = derive_phase_key(
+            &EitherSide::from("side1"),
+            &main,
+            &Phase(String::from("phase1")),
+        );
         assert_eq!(
             hex::encode(dk11),
             "3af6a61d1a111225cc8968c6ca6265efe892065c3ab46de79dda21306b062990"
         );
-        let dk12 =
-            derive_phase_key("side1", &main, &Phase(String::from("phase2")));
+        let dk12 = derive_phase_key(
+            &EitherSide::from("side1"),
+            &main,
+            &Phase(String::from("phase2")),
+        );
         assert_eq!(
             hex::encode(dk12),
             "88a1dd12182d989ff498022a9656d1e2806f17328d8bf5d8d0c9753e4381a752"
         );
-        let dk21 =
-            derive_phase_key("side2", &main, &Phase(String::from("phase1")));
+        let dk21 = derive_phase_key(
+            &EitherSide::from("side2"),
+            &main,
+            &Phase(String::from("phase1")),
+        );
         assert_eq!(
             hex::encode(dk21),
             "a306627b436ec23bdae3af8fa90c9ac927780d86be1831003e7f617c518ea689"
         );
-        let dk22 =
-            derive_phase_key("side2", &main, &Phase(String::from("phase2")));
+        let dk22 = derive_phase_key(
+            &EitherSide::from("side2"),
+            &main,
+            &Phase(String::from("phase2")),
+        );
         assert_eq!(
             hex::encode(dk22),
             "bf99e3e16420f2dad33f9b1ccb0be1462b253d639dacdb50ed9496fa528d8758"
@@ -298,13 +314,14 @@ mod test {
         // hexlified output: fe9315729668a6278a97449dc99a5f4c2102a668c6853338152906bb75526a96
         let _k = KeyMachine::new(
             &AppID(String::from("appid1")),
-            &MySide(String::from("side")),
+            &MySide::unchecked_from_string(String::from("side")),
         );
 
         let key = Key("key".as_bytes().to_vec());
         let side = "side";
         let phase = Phase(String::from("phase1"));
-        let phase1_key = derive_phase_key(side, &key, &phase);
+        let phase1_key =
+            derive_phase_key(&EitherSide::from(side), &key, &phase);
 
         assert_eq!(
             hex::encode(phase1_key),
@@ -354,7 +371,7 @@ mod test {
         let key = Key("key".as_bytes().to_vec());
         let side = "side";
         let phase = Phase(String::from("phase"));
-        let data_key = derive_phase_key(side, &key, &phase);
+        let data_key = derive_phase_key(&EitherSide::from(side), &key, &phase);
         let plaintext = "hello world";
 
         let (_nonce, encrypted) =

--- a/src/core/mailbox.rs
+++ b/src/core/mailbox.rs
@@ -215,7 +215,7 @@ mod test {
     #[test]
     fn test_mgc() {
         // add_M_essage, _G_otmailbox, then _C_onnected
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let phase1 = Phase(String::from("p1"));
         let body1 = b"body1".to_vec();
         let mbox1 = Mailbox(String::from("mbox1"));
@@ -259,7 +259,7 @@ mod test {
     #[test]
     fn test_gmc() {
         // _G_otmailbox, add_M_essage, then _C_onnected
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let phase1 = Phase(String::from("p1"));
         let body1 = b"body1".to_vec();
         let mbox1 = Mailbox(String::from("mbox1"));
@@ -303,7 +303,7 @@ mod test {
     #[test]
     fn test_cmg() {
         // _C_onnected, add_M_essage, then _G_otmailbox
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let phase1 = Phase(String::from("p1"));
         let body1 = b"body1".to_vec();
         let mbox1 = Mailbox(String::from("mbox1"));
@@ -335,7 +335,7 @@ mod test {
 
     #[test]
     fn test_messages() {
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let phase1 = Phase(String::from("p1"));
         let body1 = b"body1".to_vec();
         let mbox1 = Mailbox(String::from("mbox1"));
@@ -358,7 +358,7 @@ mod test {
         // receiving an echo of our own message is an ack, so we don't need
         // to re-send it after a Lost/Connected cycle. We do re-open the
         // mailbox though.
-        let t1 = TheirSide(String::from("side1"));
+        let t1 = TheirSide::from(String::from("side1"));
         e = m.process(RxMessage(t1.clone(), phase1.clone(), body1.clone()));
         assert_eq!(e, events![]);
         e = m.process(Lost);
@@ -368,7 +368,7 @@ mod test {
 
         // now a message from the other side means we don't need the
         // Nameplate anymore
-        let t2 = TheirSide(String::from("side2"));
+        let t2 = TheirSide::from(String::from("side2"));
         e = m.process(RxMessage(t2.clone(), phase1.clone(), body1.clone()));
         assert_eq!(
             e,

--- a/src/core/order.rs
+++ b/src/core/order.rs
@@ -79,7 +79,7 @@ mod test {
     #[test]
     fn test_messages_then_pake() {
         let mut m = super::OrderMachine::new();
-        let s1: TheirSide = TheirSide(String::from("side1"));
+        let s1: TheirSide = TheirSide::from(String::from("side1"));
         let p1: Phase = Phase(String::from("phase1"));
         let p2: Phase = Phase(String::from("phase2"));
         let p3: Phase = Phase(String::from("phase3"));
@@ -124,7 +124,7 @@ mod test {
     #[test]
     fn test_pake_then_messages() {
         let mut m = super::OrderMachine::new();
-        let s1: TheirSide = TheirSide(String::from("side1"));
+        let s1: TheirSide = TheirSide::from(String::from("side1"));
         let p1: Phase = Phase(String::from("phase1"));
         let p2: Phase = Phase(String::from("phase2"));
         let _p3: Phase = Phase(String::from("phase3"));

--- a/src/core/order.rs
+++ b/src/core/order.rs
@@ -40,7 +40,7 @@ impl OrderMachine {
         self.state = Some(match old_state {
             S0NoPake => match event {
                 GotMessage(side, phase, body) => {
-                    if phase.to_string() == "pake" {
+                    if phase.is_pake() {
                         // got a pake message
                         actions.push(K_GotPake(body));
                         for &(ref side, ref phase, ref body) in &self.queue {

--- a/src/core/receive.rs
+++ b/src/core/receive.rs
@@ -114,7 +114,7 @@ impl ReceiveMachine {
 mod test {
     use super::*;
     use crate::core::events::{
-        BossEvent, ReceiveEvent::*, SendEvent, TheirSide,
+        BossEvent, EitherSide, ReceiveEvent::*, SendEvent, TheirSide,
     };
     use crate::core::key::{derive_phase_key, derive_verifier, encrypt_data};
 
@@ -125,9 +125,13 @@ mod test {
         let masterkey = Key(b"0123456789abcdef0123456789abcdef".to_vec());
         let verifier = derive_verifier(&masterkey);
         let side1 = String::from("side1");
-        let t1 = TheirSide(side1.clone());
+        let t1 = TheirSide::from(side1.clone());
         let phase1 = Phase(String::from("phase1"));
-        let phasekey1 = derive_phase_key(&side1, &masterkey, &phase1);
+        let phasekey1 = derive_phase_key(
+            &EitherSide::from(&side1[..]),
+            &masterkey,
+            &phase1,
+        );
         let plaintext1 = b"plaintext1";
         let (_, nonce_and_ciphertext1) = encrypt_data(&phasekey1, plaintext1);
 
@@ -159,7 +163,11 @@ mod test {
 
         // second message should only provoke GotMessage
         let phase2 = Phase(String::from("phase2"));
-        let phasekey2 = derive_phase_key(&side1, &masterkey, &phase2);
+        let phasekey2 = derive_phase_key(
+            &EitherSide::from(&side1[..]),
+            &masterkey,
+            &phase2,
+        );
         let plaintext2 = b"plaintext2";
         let (_, nonce_and_ciphertext2) = encrypt_data(&phasekey2, plaintext2);
 
@@ -189,7 +197,8 @@ mod test {
 
         // all messages are ignored once we're Scared
         let phase4 = Phase(String::from("phase4"));
-        let phasekey4 = derive_phase_key(&side1, &masterkey, &phase4);
+        let phasekey4 =
+            derive_phase_key(&EitherSide::from(side1), &masterkey, &phase4);
         let plaintext4 = b"plaintext4";
         let (_, nonce_and_ciphertext4) = encrypt_data(&phasekey4, plaintext4);
 
@@ -207,7 +216,7 @@ mod test {
 
         let masterkey = Key(b"0123456789abcdef0123456789abcdef".to_vec());
         let side1 = String::from("side1");
-        let t1 = TheirSide(side1.clone());
+        let t1 = TheirSide::from(side1.clone());
 
         let mut r = ReceiveMachine::new();
 
@@ -236,7 +245,8 @@ mod test {
 
         // all messages are ignored once we're Scared
         let phase2 = Phase(String::from("phase2"));
-        let phasekey2 = derive_phase_key(&side1, &masterkey, &phase2);
+        let phasekey2 =
+            derive_phase_key(&EitherSide::from(side1), &masterkey, &phase2);
         let plaintext2 = b"plaintext2";
         let (_, nonce_and_ciphertext2) = encrypt_data(&phasekey2, plaintext2);
 

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -292,7 +292,7 @@ impl RendezvousMachine {
             add, allocate, bind, claim, close, list, open, release,
         };
         let m = match e {
-            TxBind(appid, side) => bind(&appid, &side),
+            TxBind(appid, side) => bind(appid, &side),
             TxOpen(mailbox) => open(&mailbox),
             TxAdd(phase, body) => add(&phase, &body),
             TxClose(mailbox, mood) => close(&mailbox, mood),

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -8,9 +8,7 @@
 // more code and more states here
 
 use super::api::{TimerHandle, WSHandle};
-use super::events::{
-    AppID, Events, Mailbox, MySide, Nameplate, Phase, TheirSide,
-};
+use super::events::{AppID, Events, MySide, Nameplate, Phase};
 use hex;
 use log::trace;
 use serde_json;
@@ -264,11 +262,11 @@ impl RendezvousMachine {
             Pong { .. } => (), // TODO
             Ack { .. } => (),  // we ignore this, it's only for the timing log
             Claimed { mailbox } => {
-                actions.push(NameplateEvent::RxClaimed(Mailbox(mailbox)))
+                actions.push(NameplateEvent::RxClaimed(mailbox))
             }
             Message { side, phase, body } => {
                 actions.push(MailboxEvent::RxMessage(
-                    TheirSide::from(side),
+                    side,
                     Phase(phase),
                     hex::decode(body).unwrap(),
                 ))
@@ -293,9 +291,9 @@ impl RendezvousMachine {
         };
         let m = match e {
             TxBind(appid, side) => bind(appid, side),
-            TxOpen(mailbox) => open(&mailbox),
+            TxOpen(mailbox) => open(mailbox),
             TxAdd(phase, body) => add(&phase, &body),
-            TxClose(mailbox, mood) => close(&mailbox, mood),
+            TxClose(mailbox, mood) => close(mailbox, mood),
             TxClaim(nameplate) => claim(&nameplate),
             TxRelease(nameplate) => release(&nameplate),
             TxAllocate => allocate(),

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -268,7 +268,7 @@ impl RendezvousMachine {
             }
             Message { side, phase, body } => {
                 actions.push(MailboxEvent::RxMessage(
-                    TheirSide(side),
+                    TheirSide::from(side),
                     Phase(phase),
                     hex::decode(body).unwrap(),
                 ))
@@ -292,7 +292,7 @@ impl RendezvousMachine {
             add, allocate, bind, claim, close, list, open, release,
         };
         let m = match e {
-            TxBind(appid, side) => bind(appid, &side),
+            TxBind(appid, side) => bind(appid, side),
             TxOpen(mailbox) => open(&mailbox),
             TxAdd(phase, body) => add(&phase, &body),
             TxClose(mailbox, mood) => close(&mailbox, mood),
@@ -340,7 +340,7 @@ mod test {
 
     #[test]
     fn create() {
-        let side = MySide(String::from("side1"));
+        let side = MySide::unchecked_from_string(String::from("side1"));
         let mut r = super::RendezvousMachine::new(
             &AppID(String::from("appid")),
             "url",
@@ -384,8 +384,13 @@ mod test {
                 b = b0;
                 match &b {
                     &RC_TxBind(ref appid0, ref side0) => {
-                        assert_eq!(appid0.to_string(), "appid");
-                        assert_eq!(side0, &MySide(String::from("side1")));
+                        assert_eq!(&appid0.0, "appid");
+                        assert_eq!(
+                            side0,
+                            &MySide::unchecked_from_string(String::from(
+                                "side1"
+                            ))
+                        );
                     }
                     _ => panic!(),
                 }
@@ -413,8 +418,8 @@ mod test {
                 if let OutboundMessage::Bind { appid, side } =
                     deserialize_outbound(&m)
                 {
-                    assert_eq!(appid, "appid");
-                    assert_eq!(side, "side1");
+                    assert_eq!(&appid.0, "appid");
+                    assert_eq!(&side.0, "side1");
                 } else {
                     panic!();
                 }
@@ -478,7 +483,7 @@ mod test {
 
     #[test]
     fn first_connect_fails() {
-        let side = MySide(String::from("side1"));
+        let side = MySide::unchecked_from_string(String::from("side1"));
         let mut r = super::RendezvousMachine::new(
             &AppID(String::from("appid")),
             "url",

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -292,7 +292,7 @@ impl RendezvousMachine {
         let m = match e {
             TxBind(appid, side) => bind(appid, side),
             TxOpen(mailbox) => open(mailbox),
-            TxAdd(phase, body) => add(&phase, &body),
+            TxAdd(phase, body) => add(phase, &body),
             TxClose(mailbox, mood) => close(mailbox, mood),
             TxClaim(nameplate) => claim(&nameplate),
             TxRelease(nameplate) => release(&nameplate),

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -83,7 +83,7 @@ mod test {
 
     #[test]
     fn test_queue() {
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let mut m = SendMachine::new(&s);
 
         // sending messages before we have a key: messages are queued
@@ -132,7 +132,7 @@ mod test {
 
     #[test]
     fn test_key_first() {
-        let s = MySide(String::from("side1"));
+        let s = MySide::unchecked_from_string(String::from("side1"));
         let mut m = SendMachine::new(&s);
 
         let key = Key("key".as_bytes().to_vec());

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -1,5 +1,5 @@
 use super::api::Mood;
-use super::events::{AppID, Mailbox, MySide, TheirSide};
+use super::events::{AppID, Mailbox, MySide, Phase, TheirSide};
 use super::util;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{self, Value};
@@ -20,7 +20,7 @@ pub enum OutboundMessage {
     Claim { nameplate: String },
     Release { nameplate: String }, // TODO: nominally optional
     Open { mailbox: Mailbox },
-    Add { phase: String, body: String },
+    Add { phase: Phase, body: String },
     Close { mailbox: Mailbox, mood: Mood },
     Ping { ping: u64 },
 }
@@ -49,13 +49,13 @@ pub fn open(mailbox: Mailbox) -> OutboundMessage {
     OutboundMessage::Open { mailbox }
 }
 
-pub fn add(phase: &str, body: &[u8]) -> OutboundMessage {
+pub fn add(phase: Phase, body: &[u8]) -> OutboundMessage {
     // TODO: make this take Vec<u8>, do the hex-encoding internally
     let hexstr = util::bytes_to_hexstr(body);
 
     OutboundMessage::Add {
-        phase: phase.to_string(),
         body: hexstr,
+        phase,
     }
 }
 
@@ -175,7 +175,7 @@ mod test {
 
     #[test]
     fn test_add() {
-        let m1 = add("phase1", b"body");
+        let m1 = add(Phase(String::from("phase1")), b"body");
         let s = serde_json::to_string(&m1).unwrap();
         let m2: Value = from_str(&s).unwrap();
         assert_eq!(

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -14,7 +14,7 @@ pub struct Nameplate {
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "type")]
 pub enum OutboundMessage {
-    Bind { appid: String, side: String },
+    Bind { appid: AppID, side: String },
     List {},
     Allocate {},
     Claim { nameplate: String },
@@ -25,10 +25,10 @@ pub enum OutboundMessage {
     Ping { ping: u64 },
 }
 
-pub fn bind(appid: &AppID, side: &MySide) -> OutboundMessage {
+pub fn bind(appid: AppID, side: &MySide) -> OutboundMessage {
     OutboundMessage::Bind {
-        appid: appid.to_string(),
         side: side.to_string(),
+        appid,
     }
 }
 pub fn list() -> OutboundMessage {

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -14,7 +14,7 @@ pub struct Nameplate {
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "type")]
 pub enum OutboundMessage {
-    Bind { appid: AppID, side: String },
+    Bind { appid: AppID, side: MySide },
     List {},
     Allocate {},
     Claim { nameplate: String },
@@ -25,11 +25,8 @@ pub enum OutboundMessage {
     Ping { ping: u64 },
 }
 
-pub fn bind(appid: AppID, side: &MySide) -> OutboundMessage {
-    OutboundMessage::Bind {
-        side: side.to_string(),
-        appid,
-    }
+pub fn bind(appid: AppID, side: MySide) -> OutboundMessage {
+    OutboundMessage::Bind { appid, side }
 }
 pub fn list() -> OutboundMessage {
     OutboundMessage::List {}
@@ -129,8 +126,8 @@ mod test {
     #[test]
     fn test_bind() {
         let m1 = bind(
-            &AppID(String::from("appid")),
-            &MySide(String::from("side1")),
+            AppID(String::from("appid")),
+            MySide::unchecked_from_string(String::from("side1")),
         );
         let s = serde_json::to_string(&m1).unwrap();
         let m2: Value = from_str(&s).unwrap();

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -21,7 +21,7 @@ pub enum OutboundMessage {
     Release { nameplate: String }, // TODO: nominally optional
     Open { mailbox: String },
     Add { phase: String, body: String },
-    Close { mailbox: String, mood: String },
+    Close { mailbox: String, mood: Mood },
     Ping { ping: u64 },
 }
 
@@ -67,7 +67,7 @@ pub fn add(phase: &str, body: &[u8]) -> OutboundMessage {
 pub fn close(mailbox: &Mailbox, mood: Mood) -> OutboundMessage {
     OutboundMessage::Close {
         mailbox: mailbox.0.to_string(),
-        mood: mood.to_string(),
+        mood,
     }
 }
 

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -16,7 +16,7 @@ pub fn filt(ev: Events) -> Events {
 #[test]
 fn test_phase() {
     let p = Phase(String::from("pake"));
-    assert_eq!(p.to_string(), "pake"); // Order looks for "pake"
+    assert!(p.is_pake()); // Order looks for "pake"
 }
 
 #[test]

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -73,8 +73,8 @@ fn create() {
             if let OutboundMessage::Bind { appid, side } =
                 deserialize_outbound(&m)
             {
-                assert_eq!(appid, "appid");
-                _got_side = &side; // random
+                assert_eq!(&appid.0, "appid");
+                _got_side = &side.0; // random
             } else {
                 panic!();
             }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -21,18 +21,28 @@ fn test_phase() {
 
 #[test]
 fn test_mood() {
-    // these strings are part of the wire protocol, so .to_string() must
-    // return exactly these values, even if i18n or other human-facing
-    // concerns want it otherwise. If we must change our implementation of
-    // the Display trait, then we need to add a different trait specifically
-    // for serialization onto the wire. They must match the strings used in
-    // the Python version in src/wormhole/_boss.py , in calls to
-    // self._T.close()
-    assert_eq!(Mood::Happy.to_string(), "happy");
-    assert_eq!(Mood::Lonely.to_string(), "lonely");
-    assert_eq!(Mood::Errory.to_string(), "errory");
-    assert_eq!(Mood::Scared.to_string(), "scary");
-    assert_eq!(Mood::Unwelcome.to_string(), "unwelcome");
+    // These must match the strings used in the Python version in
+    // src/wormhole/_boss.py , in calls to self._T.close()
+    assert_eq!(
+        String::from(r#""happy""#),
+        serde_json::to_string(&Mood::Happy).unwrap()
+    );
+    assert_eq!(
+        String::from(r#""lonely""#),
+        serde_json::to_string(&Mood::Lonely).unwrap()
+    );
+    assert_eq!(
+        String::from(r#""errory""#),
+        serde_json::to_string(&Mood::Errory).unwrap()
+    );
+    assert_eq!(
+        String::from(r#""scary""#),
+        serde_json::to_string(&Mood::Scared).unwrap()
+    );
+    assert_eq!(
+        String::from(r#""unwelcome""#),
+        serde_json::to_string(&Mood::Unwelcome).unwrap()
+    );
 }
 
 use super::{Action, IOAction, IOEvent, TimerHandle, WSHandle, WormholeCore};

--- a/src/core/timing.rs
+++ b/src/core/timing.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_derive::Serialize;
 use serde_json::{json, Value};
 use std::time::SystemTime;
@@ -33,7 +34,7 @@ pub fn new_timelog(name: &str, when: Option<f64>) -> TimingLogEvent {
 }
 
 impl TimingLogEvent {
-    pub fn detail(&mut self, name: &str, value: &str) {
+    pub fn detail<S: Serialize + ?Sized>(&mut self, name: &str, value: &S) {
         self.details[name] = json!(value);
     }
 


### PR DESCRIPTION
From the "let the knife do the work" school of Rust, this pull request has a net reduction of about twenty lines by avoiding manual stringification in favour of implementing the serde traits directly on the corresponding API types.

For more information on some of what I'm doing here, read <https://serde.rs/container-attrs.html>.

Also fixes #49; instead of implementing Display, it implements Serialize.