### PR TITLE
remove rendundant 'use' statements

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,7 +2,6 @@ use clap::{
     crate_authors, crate_description, crate_name, crate_version, App, Arg,
     SubCommand,
 };
-use env_logger;
 use magic_wormhole::core::{
     error_message, message, message_ack, OfferType, PeerMessage,
 };

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -1,6 +1,5 @@
 use super::events::{Code, Key};
 use super::util::maybe_utf8;
-use hex;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::error::Error;

--- a/src/core/boss.rs
+++ b/src/core/boss.rs
@@ -4,8 +4,6 @@ use super::wordlist::default_wordlist;
 use serde_json::json;
 use std::sync::Arc;
 
-use serde_json;
-
 // we process these
 use super::api::APIEvent;
 use super::events::BossEvent;

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -1,4 +1,3 @@
-use hex;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -1,4 +1,3 @@
-use hex;
 use hkdf::Hkdf;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -9,9 +9,7 @@
 
 use super::api::{TimerHandle, WSHandle};
 use super::events::{AppID, Events, MySide, Nameplate, Phase};
-use hex;
 use log::trace;
-use serde_json;
 // we process these
 use super::api::IOEvent;
 use super::events::RendezvousEvent;

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,6 +1,4 @@
-use hex;
 use rand::{rngs::OsRng, RngCore};
-use std;
 use std::str;
 
 pub fn random_bytes(bytes: &mut [u8]) {

--- a/src/core/wordlist.rs
+++ b/src/core/wordlist.rs
@@ -39,7 +39,7 @@ impl Wordlist {
                     suffix.push_str(&word);
                 } else {
                     let p = prefix.len() - lp;
-                    suffix.split_off(p as usize);
+                    suffix.truncate(p as usize);
                     suffix.push_str(&word);
                 }
 

--- a/src/io/blocking.rs
+++ b/src/io/blocking.rs
@@ -9,7 +9,6 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use std::time;
 use url::Url;
-use ws;
 
 enum ToCore {
     API(APIEvent),


### PR DESCRIPTION
caught by the new clippy lints in rust 1.43