### PR TITLE
increase MSRV to 1.42

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2
 jobs:
   build_msrv:
     docker:
-      - image: circleci/rust:1.40
+      - image: circleci/rust:1.42
     steps:
       - checkout
       - restore_cache:
-          key: project-cache-1.40
+          key: project-cache-1.42
       - run:
           name: cargo version
           command: cargo version
@@ -17,7 +17,7 @@ jobs:
           name: cargo test
           command: cargo test
       - save_cache:
-          key: project-cache-1.40
+          key: project-cache-1.42
           paths:
             - "~/.cargo"
             - "./target"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.40.0 # MSRV
+          - 1.42.0 # MSRV
           - stable
           - nightly
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2018"
 description = "Get things from one computer to another, safely"
 readme = "README.md"
 
-# the MSRV is: rust-1.40.0
+# the MSRV is: rust-1.42.0
+# * rustyline-derive-0.3.1 needs 1.42: 'use proc_macro' without 'extern crate proc_macro'
 # * rustyline-6.0 needs 1.40: #[non_exhaustive]
 # * xsalsa20poly1305-0.3.1 needs 1.37: copy_within
 # * sodiumoxide-0.2.4 needs 1.36: mem::MaybeUninit


### PR DESCRIPTION
up through rust-1.41.1, we get this error:

```
error[E0432]: unresolved import `proc_macro`
 --> /Users/warner/.cargo/registry/src/github.com-1ecc6299db9ec823/rustyline-derive-0.3.1/src/lib.rs:1:5
  |
1 | use proc_macro::TokenStream;
  |     ^^^^^^^^^^ help: a similar path exists: `syn::proc_macro`
```

I think that means rustyline-derive removed the `extern crate proc_macro`
which was required until rust-1.42, or something similar, thus raising their
own effective MSRV.